### PR TITLE
Make sure example has backup dir exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ services:
     image: hermsi/ark-server:latest
     volumes:
       - ${HOME}/ark-server:/app
+      - ${HOME}/ark-server-backups:/home/steam/ARK-Backups
     environment:
       - SESSION_NAME=${SESSION_NAME}
       - SERVER_MAP=${SERVER_MAP}


### PR DESCRIPTION
It was surprising where `arkmanager backup` puts its files, its inside the container, so not actually backed up