### PR TITLE
Added verbose flags + Changed how server and mods are auto-updated

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -11,13 +11,9 @@ function may_update() {
 
   echo "\$UPDATE_ON_START is 'true'..."
 
-  # 0: No update is available
-  if ${ARKMANAGER} checkupdate; then
-    echo "...no update available"
-    return
-  fi
-
-  ${ARKMANAGER} update --force --backup
+  # auto checks if a update is needed, if yes, then update the server or mods 
+  # (otherwise it just does nothing)
+  ${ARKMANAGER} update --verbose --update-mods --backup
 }
 
 function create_missing_dir() {
@@ -88,7 +84,7 @@ if [[ ! -d ${ARK_SERVER_VOLUME}/server ]] || [[ ! -f ${ARK_SERVER_VOLUME}/server
     "${ARK_SERVER_VOLUME}/server/ShooterGame/Content/Mods" \
     "${ARK_SERVER_VOLUME}/server/ShooterGame/Binaries/Linux"
   touch "${ARK_SERVER_VOLUME}/server/ShooterGame/Binaries/Linux/ShooterGameServer"
-  ${ARKMANAGER} install
+  ${ARKMANAGER} install --verbose
 else
   may_update
 fi
@@ -103,4 +99,4 @@ else
   echo "No crontab set"
 fi
 
-exec ${ARKMANAGER} run "${args[@]}"
+exec ${ARKMANAGER} run --verbose "${args[@]}"


### PR DESCRIPTION
Due to slow internet or a slow cpu, the initial install command can take quite a while, and I wasn't sure whether it was hanging or it was making progress.
Therefore, I propose adding the --verbose flags, which makes the progress being printed into the console.

The other change is changing the way update works:
arkmanager update autochecks, whether there is an update needed (without the --force flag), just like it was before with the checkupdate. However, this prevents the option to update mods with the --update-mods flag.

Other than that, very useful project and way easier than using steamcmd or arkmanager directly! Thank you!