### PR TITLE
Updated DEBUG flag to allow for a false or 0 value, fixed multiple args

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -100,4 +100,4 @@ else
 fi
 
 
-exec ${ARKMANAGER} run --verbose "${args[@]}"
+exec ${ARKMANAGER} run --verbose ${args[@]}

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-[[ -z "${DEBUG}" ]] || set -x
+[[ -z "${DEBUG}" ]] || [[ "${DEBUG,,}" = "false" ]] || [[ "${DEBUG,,}" = "0" ]] || set -x
 
 function may_update() {
   if [[ "${UPDATE_ON_START}" != "true" ]]; then


### PR DESCRIPTION
Found an issue where the args being passed in would get sent to arkmanager as a long string, rather than multiple arguments. Resolved this by removing the quotes. This may be necessary for running in a stack when passing args using something like compose or kubernetes. 

Also along the same vein, I was using the DEBUG flag to figure this out, and being one might set the flag to 0 or false to turn it off, rather than deleting it.