### PR TITLE
Update ark-server-tools to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM        cm2network/steamcmd:root
 
 LABEL       MAINTAINER="https://github.com/Hermsi1337/"
 
-ARG         ARK_TOOLS_VERSION="1.6.61a"
+ARG         ARK_TOOLS_VERSION="1.6.65"
 ARG         IMAGE_VERSION="dev"
 
 ENV         IMAGE_VERSION="${IMAGE_VERSION}" \


### PR DESCRIPTION
I noticed an issue with arkmanager not being able to install mods, which seems to have been fixed on the latest version.