### PR TITLE
Added procps to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN         set -x && \
                                 bzip2 \
                                 gosu \
                                 cron \
+                                procps \
             && \
             curl -L "https://github.com/arkmanager/ark-server-tools/archive/v${ARK_TOOLS_VERSION}.tar.gz" \
                 | tar -xvzf - -C /tmp/ && \


### PR DESCRIPTION
Hi,

in the discussion of  #112 I noticed:
`/usr/local/bin/arkmanager: line 1480: pgrep: command not found`

This of course doesn't solve the root problem, but since pgrep is used in multiple places in the arkmanager I guess it would be a good idea to add the procps package to the image.