### PR TITLE
Use netinstall.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
-deploy/.env
-deploy/docker-compose.override.yml
+deploy/
+!deploy/example.env
+!deploy/docker-compose.yml
 volumes/

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,14 +43,13 @@ RUN         set -x && \
                                 cron \
                                 pcregrep \
                                 procps \
-                                git \
-            && \
-            git clone https://github.com/arkmanager/ark-server-tools.git /tmp/ark-server-tools && \
-            bash -c "cd /tmp/ark-server-tools && git checkout '${ARK_TOOLS_VERSION}' && bash -x tools/install.sh '${USER}'" && \
+            commit=$([ "${ARK_TOOLS_VERSION#v}" != "${ARK_TOOLS_VERSION}" ] && curl -s "https://api.github.com/repos/arkmanager/ark-server-tools/git/refs/tags/${ARK_TOOLS_VERSION}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p' || echo -n "${ARK_TOOLS_VERSION}") && \
+            curl -sL https://raw.githubusercontent.com/arkmanager/ark-server-tools/master/netinstall.sh | \
+            sed -re "s/^  doInstallFromRelease/  doInstallFromCommit ${commit}/" | bash -s ${USER} && \
             ln -s /usr/local/bin/arkmanager /usr/bin/arkmanager && \
             install -d -o ${USER} ${ARK_SERVER_VOLUME} && \
             su ${USER} -c "bash -x ${STEAMCMDDIR}/steamcmd.sh +login anonymous +quit" && \
-            apt-get purge git -y && apt-get -qq autoclean && apt-get -qq autoremove && apt-get -qq clean && \
+            apt-get -qq autoclean && apt-get -qq autoremove && apt-get -qq clean && \
             rm -rf /tmp/* /var/cache/*
 
 COPY        bin/    /

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,10 @@ RUN         set -x && \
                                 cron \
                                 pcregrep \
                                 procps \
-            commit=$([ "${ARK_TOOLS_VERSION#v}" != "${ARK_TOOLS_VERSION}" ] && curl -s "https://api.github.com/repos/arkmanager/ark-server-tools/git/refs/tags/${ARK_TOOLS_VERSION}" | sed -n 's/^ *"sha": "\(.*\)",.*/\1/p' || echo -n "${ARK_TOOLS_VERSION}") && \
-            curl -sL https://raw.githubusercontent.com/arkmanager/ark-server-tools/master/netinstall.sh | \
-            sed -re "s/^  doInstallFromRelease/  doInstallFromCommit ${commit}/" | bash -s ${USER} && \
+            && \
+            opt=$([ "${ARK_TOOLS_VERSION#v}" != "${ARK_TOOLS_VERSION}" ] && echo -n "--tag" || echo -n "--commit") && \
+            curl -sL https://raw.githubusercontent.com/MusclePr/ark-server-tools/refs/heads/feature/netinstall-commit-option/netinstall.sh | \
+            bash -s ${USER} ${opt}=${ARK_TOOLS_VERSION} && \
             ln -s /usr/local/bin/arkmanager /usr/bin/arkmanager && \
             install -d -o ${USER} ${ARK_SERVER_VOLUME} && \
             su ${USER} -c "bash -x ${STEAMCMDDIR}/steamcmd.sh +login anonymous +quit" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN         set -x && \
                                 procps \
             && \
             opt=$([ "${ARK_TOOLS_VERSION#v}" != "${ARK_TOOLS_VERSION}" ] && echo -n "--tag" || echo -n "--commit") && \
-            curl -sL https://raw.githubusercontent.com/MusclePr/ark-server-tools/refs/heads/feature/netinstall-commit-option/netinstall.sh | \
+            curl -sL https://raw.githubusercontent.com/arkmanager/ark-server-tools/refs/heads/master/netinstall.sh | \
             bash -s ${USER} ${opt}=${ARK_TOOLS_VERSION} && \
             ln -s /usr/local/bin/arkmanager /usr/bin/arkmanager && \
             install -d -o ${USER} ${ARK_SERVER_VOLUME} && \


### PR DESCRIPTION
I found netinstall.sh and tried using that.

However, there was no option to specify a commit hash, so I made some modifications to address the issue.

Because this method was unstable, I requested additional options be added to netinstall.sh.

- The deploy directory is basically ignored, but only the necessary files are treated as exceptions.