### PR TITLE
[publish_preview - Get ARK Tool Version] Fixes to curl to make errors more clear

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Get ARK Tools Version
         id: ark_tools
         run: |
-          ARK_TOOLS_VERSION=$(curl -s https://api.github.com/repos/arkmanager/ark-server-tools/commits | jq '.[0].sha' | cut -d '"' -f 2)
+          ARK_TOOLS_VERSION=$(curl -fsSL 'https://api.github.com/repos/arkmanager/ark-server-tools/commits' | jq -r '.[0].sha')
           # ARK_TOOLS_VERSION=$(curl -s "https://api.github.com/repos/arkmanager/ark-server-tools/tags" | jq -r '.[0].name' | egrep -o "[0-9]+\.[0-9]+\.[0-9]+([a-z]+)?")
           echo "ARK_TOOLS_VERSION=$ARK_TOOLS_VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
This PR is to improve [handling curl of the Get ARK Tools Version step](https://github.com/Hermsi1337/docker-ark-server/actions/runs/19187967694/job/54858092986?pr=121#step:5:9).

It may have just been a coincidence curl failed, but I tried to make it a bit more robust.

@Hermsi1337 
Thank you for your continued support.
