### PR TITLE
Modernize GitHub Actions CI (official Docker actions, GHCR, Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,166 +1,95 @@
-name: Build and Deploy Docker
+name: Build and Publish
 
 on:
   push:
     branches:
-      - '**'
+      - master
   workflow_dispatch:
   schedule:
     - cron: '0 2 * * 1'  # every monday at 02:00 UTC
 
+# Only ever run one publish per ref at a time; a newer push supersedes an
+# in-flight build.
+concurrency:
+  group: build-and-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write  # required to push to ghcr.io
+
 env:
-  IMAGE_NAME: hermsi/ark-server
+  DOCKERHUB_IMAGE: hermsi/ark-server
+  QUAY_IMAGE: quay.io/hermsi1337/ark-server
+  GHCR_IMAGE: ghcr.io/hermsi1337/ark-server
 
 jobs:
-  build:
-    if: github.ref != 'refs/heads/master' && github.event_name != 'schedule'
+  build-and-publish:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        IMAGE_NAME: [ "hermsi/ark-server" ]
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v7
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y curl jq grep
-
-      - name: Get ARK Tools Version
+      - name: Determine ARK server tools version
         id: ark_tools
         run: |
-          ARK_TOOLS_VERSION=$(curl -s https://api.github.com/repos/arkmanager/ark-server-tools/commits | jq '.[0].sha' | cut -d '"' -f 2)
-          # ARK_TOOLS_VERSION=$(curl -s "https://api.github.com/repos/arkmanager/ark-server-tools/tags" | jq -r '.[0].name' | egrep -o "[0-9]+\.[0-9]+\.[0-9]+([a-z]+)?")
-          echo "ARK_TOOLS_VERSION=$ARK_TOOLS_VERSION" >> $GITHUB_ENV
+          ARK_TOOLS_VERSION="$(curl -fsSL 'https://api.github.com/repos/arkmanager/ark-server-tools/commits' | jq -r '.[0].sha')"
+          echo "version=${ARK_TOOLS_VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Bash Syntax Check
-        run: |
-          find . -name "*.sh" -print0 | xargs -0 -r -n1 bash -n
+      - name: Set build timestamp
+        id: timestamp
+        run: echo "value=$(date +%s)" >> "$GITHUB_OUTPUT"
 
-      - name: Set timestamp
-        run: echo "TIMESTAMP=$(date +%s)" >> $GITHUB_ENV
+      - name: Check shell script syntax
+        run: find . -name '*.sh' -print0 | xargs -0 -r -n1 bash -n
 
-      - name: Build Docker Image
-        run: |
-          docker build \
-            --no-cache \
-            --pull \
-            --build-arg ARK_TOOLS_VERSION="${{ env.ARK_TOOLS_VERSION }}" \
-            --tag "${{ matrix.IMAGE_NAME }}:tools-${{ env.ARK_TOOLS_VERSION }}" \
-            --tag "${{ matrix.IMAGE_NAME }}:latest" \
-            --tag "${{ matrix.IMAGE_NAME }}:latest-${{ env.TIMESTAMP }}" \
-            --file "${{ github.workspace }}/Dockerfile" \
-            "${{ github.workspace }}"
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  deploy:
-    if: github.ref == 'refs/heads/master' || github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        IMAGE_NAME: [ "hermsi/ark-server", "quay.io/hermsi1337/ark-server" ]
-    steps:
-      - uses: actions/checkout@v4
+      - name: Log in to Quay.io
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y curl jq grep
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ env.QUAY_IMAGE }}
+            ${{ env.GHCR_IMAGE }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=latest-${{ steps.timestamp.outputs.value }}
+            type=raw,value=tools-${{ steps.ark_tools.outputs.version }}
 
-      - name: Get ARK Tools Version
-        id: ark_tools
-        run: |
-          ARK_TOOLS_VERSION=$(curl -s https://api.github.com/repos/arkmanager/ark-server-tools/commits | jq '.[0].sha' | cut -d '"' -f 2)
-          # ARK_TOOLS_VERSION=$(curl -s "https://api.github.com/repos/arkmanager/ark-server-tools/tags" | jq -r '.[0].name' | egrep -o "[0-9]+\.[0-9]+\.[0-9]+([a-z]+)?")
-          echo "ARK_TOOLS_VERSION=$ARK_TOOLS_VERSION" >> $GITHUB_ENV
-
-      - name: Bash Syntax Check
-        run: |
-          find . -name "*.sh" -print0 | xargs -0 -r -n1 bash -n
-
-      - name: Set timestamp
-        run: echo "TIMESTAMP=$(date +%s)" >> $GITHUB_ENV
-
-      - name: Write Docker config.json
-        run: |
-          mkdir -p $HOME/.docker
-          echo '${{ secrets.DOCKER_CONFIG_JSON }}' > $HOME/.docker/config.json
-          chmod 0600 $HOME/.docker/config.json
-
-      - name: Build Docker Image
-        run: |
-          docker build \
-            --no-cache \
-            --pull \
-            --build-arg ARK_TOOLS_VERSION="${{ env.ARK_TOOLS_VERSION }}" \
-            --build-arg IMAGE_VERSION="${{ env.TIMESTAMP }}" \
-            --tag "${{ matrix.IMAGE_NAME }}:tools-${{ env.ARK_TOOLS_VERSION }}" \
-            --tag "${{ matrix.IMAGE_NAME }}:latest" \
-            --tag "${{ matrix.IMAGE_NAME }}:latest-${{ env.TIMESTAMP }}" \
-            --file "${{ github.workspace }}/Dockerfile" \
-            "${{ github.workspace }}"
-
-      - name: Push Docker Images
-        run: |
-          docker push "${{ matrix.IMAGE_NAME }}:tools-${{ env.ARK_TOOLS_VERSION }}"
-          docker push "${{ matrix.IMAGE_NAME }}:latest"
-          docker push "${{ matrix.IMAGE_NAME }}:latest-${{ env.TIMESTAMP }}"
-
-  pr_publish:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'publish-preview') }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        IMAGE_NAME: [ "hermsi/ark-server" ]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
-
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y curl jq grep
-
-      - name: Get ARK Tools Version
-        id: ark_tools
-        run: |
-          ARK_TOOLS_VERSION=$(curl -s "https://api.github.com/repos/arkmanager/ark-server-tools/tags" | jq -r '.[0].name' | egrep -o "[0-9]+\.[0-9]+\.[0-9]+([a-z]+)?")
-          echo "ARK_TOOLS_VERSION=$ARK_TOOLS_VERSION" >> $GITHUB_ENV
-
-      - name: Bash Syntax Check
-        run: |
-          find . -name "*.sh" -print0 | xargs -0 -r -n1 bash -n
-
-      - name: Set timestamp
-        run: echo "TIMESTAMP=$(date +%s)" >> $GITHUB_ENV
-
-      - name: Write Docker config.json
-        run: |
-          mkdir -p $HOME/.docker
-          echo '${{ secrets.DOCKER_CONFIG_JSON }}' > $HOME/.docker/config.json
-          chmod 0600 $HOME/.docker/config.json
-
-      - name: Build Docker Image
-        run: |
-          PR_TAG="pr-${{ github.event.pull_request.number }}"
-          docker build \
-            --no-cache \
-            --pull \
-            --build-arg ARK_TOOLS_VERSION="${{ env.ARK_TOOLS_VERSION }}" \
-            --tag "${{ matrix.IMAGE_NAME }}:$PR_TAG" \
-            --tag "${{ matrix.IMAGE_NAME }}:pr-latest" \
-            --file "${{ github.workspace }}/Dockerfile" \
-            "${{ github.workspace }}"
-
-      - name: Push Docker Images
-        run: |
-          PR_TAG="pr-${{ github.event.pull_request.number }}"
-          docker push "${{ matrix.IMAGE_NAME }}:$PR_TAG"
-          docker push "${{ matrix.IMAGE_NAME }}:pr-latest"
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          pull: true
+          no-cache: true
+          build-args: |
+            ARK_TOOLS_VERSION=${{ steps.ark_tools.outputs.version }}
+            IMAGE_VERSION=${{ steps.timestamp.outputs.value }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,65 +1,102 @@
-name: Build and Deploy Docker
+name: Build PR Preview
 
 on:
   pull_request:
     branches:
       - master
 
+# One preview build per pull request; superseded by newer pushes to the PR.
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write  # required to push to ghcr.io for same-repo PRs
+
 env:
-  IMAGE_NAME: hermsi/ark-server
+  DOCKERHUB_IMAGE: hermsi/ark-server
+  QUAY_IMAGE: quay.io/hermsi1337/ark-server
+  GHCR_IMAGE: ghcr.io/hermsi1337/ark-server
 
 jobs:
-  publish_preview:
-    if: github.ref != 'refs/heads/master'
+  preview:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        IMAGE_NAME: ["hermsi/ark-server", "quay.io/hermsi1337/ark-server" ]
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v7
 
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y curl jq grep
-
-      - name: Get ARK Tools Version
+      - name: Determine ARK server tools version
         id: ark_tools
         run: |
-          ARK_TOOLS_VERSION=$(curl -fsSL 'https://api.github.com/repos/arkmanager/ark-server-tools/commits' | jq -r '.[0].sha')
-          # ARK_TOOLS_VERSION=$(curl -s "https://api.github.com/repos/arkmanager/ark-server-tools/tags" | jq -r '.[0].name' | egrep -o "[0-9]+\.[0-9]+\.[0-9]+([a-z]+)?")
-          echo "ARK_TOOLS_VERSION=$ARK_TOOLS_VERSION" >> $GITHUB_ENV
+          ARK_TOOLS_VERSION="$(curl -fsSL 'https://api.github.com/repos/arkmanager/ark-server-tools/commits' | jq -r '.[0].sha')"
+          echo "version=${ARK_TOOLS_VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Bash Syntax Check
+      - name: Check shell script syntax
+        run: find . -name '*.sh' -print0 | xargs -0 -r -n1 bash -n
+
+      # Fork pull requests do not receive repository secrets, so they can only
+      # build for validation. Same-repo PRs push previews, but only once the
+      # registry credentials have actually been configured, so the build stays
+      # green while the DOCKERHUB_/QUAY_ secrets are still missing.
+      - name: Determine push eligibility
+        id: push
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          find . -name "*.sh" -print0 | xargs -0 -r -n1 bash -n
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Set timestamp
-        run: echo "TIMESTAMP=$(date +%s)" >> $GITHUB_ENV
+      - name: Log in to Docker Hub
+        if: steps.push.outputs.enabled == 'true'
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Write Docker config.json
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        run: |
-          mkdir -p $HOME/.docker
-          echo '${{ secrets.DOCKER_CONFIG_JSON }}' > $HOME/.docker/config.json
-          chmod 0600 $HOME/.docker/config.json
+      - name: Log in to Quay.io
+        if: steps.push.outputs.enabled == 'true'
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
 
-      - name: Build Docker Image
-        run: |
-          PR_TAG="pr-${{ github.event.pull_request.number }}"
-          docker build \
-            --no-cache \
-            --pull \
-            --build-arg ARK_TOOLS_VERSION="${{ env.ARK_TOOLS_VERSION }}" \
-            --tag "${{ matrix.IMAGE_NAME }}:$PR_TAG" \
-            --file "${{ github.workspace }}/Dockerfile" \
-            "${{ github.workspace }}"
+      - name: Log in to GitHub Container Registry
+        if: steps.push.outputs.enabled == 'true'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push Docker Images
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        run: |
-          PR_TAG="pr-${{ github.event.pull_request.number }}"
-          docker push "${{ matrix.IMAGE_NAME }}:$PR_TAG"
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.DOCKERHUB_IMAGE }}
+            ${{ env.QUAY_IMAGE }}
+            ${{ env.GHCR_IMAGE }}
+          tags: |
+            type=raw,value=pr-${{ github.event.pull_request.number }}
+
+      - name: Build and push PR preview
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: ${{ steps.push.outputs.enabled == 'true' }}
+          pull: true
+          no-cache: true
+          build-args: |
+            ARK_TOOLS_VERSION=${{ steps.ark_tools.outputs.version }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,114 @@
+# AGENTS.md
+
+Working guide for AI agents and humans contributing to this repository.
+Verify anything you rely on against the actual files — this document summarizes
+them, it does not replace them.
+
+## What this is
+
+A Docker image for **ARK: Survival Evolved** dedicated servers, installed via
+`steamcmd` and managed with
+[arkmanager / ark-server-tools](https://github.com/arkmanager/ark-server-tools).
+Base image: `cm2network/steamcmd:root`.
+
+Published to three registries (same image, same tags):
+
+- Docker Hub: `hermsi/ark-server`
+- Quay.io: `quay.io/hermsi1337/ark-server`
+- GHCR: `ghcr.io/hermsi1337/ark-server`
+
+**Tag schema — public contract, do not change:**
+
+| Tag | Meaning |
+|---|---|
+| `latest` | Most recent build from `master` |
+| `latest-<unix-timestamp>` | Immutable pointer to a specific `latest` build |
+| `tools-<sha>` | Build pinned to an ark-server-tools commit SHA |
+| `pr-<n>` | Preview build for pull request `<n>` (same-repo PRs only) |
+
+Users pin deployments to these tags. Renaming or dropping any of them breaks
+downstream compose files and scripts.
+
+## Repository layout
+
+| Path | Purpose |
+|---|---|
+| `Dockerfile` | Image build; installs arkmanager via upstream `netinstall.sh` |
+| `bin/docker-entrypoint.sh` | Container entrypoint (root: setup, cron, drops to steam user) |
+| `bin/steam-entrypoint.sh` | Server bootstrap/run as the `steam` user |
+| `conf.d/` | Templates copied into the image (`arkmanager.cfg`, `arkmanager-user.cfg`, `crontab`) |
+| `deploy/` | Example `docker-compose.yml` + `example.env` for end users |
+| `.github/workflows/build-and-deploy.yml` | "Build and Publish" — builds and pushes to all three registries |
+| `.github/workflows/deploy-preview.yml` | "Build PR Preview" — builds PRs, pushes `pr-<n>` for same-repo PRs |
+| `.github/dependabot.yml` | Weekly `github-actions` version updates |
+
+## CI/CD
+
+**Build and Publish** (`build-and-deploy.yml`):
+
+- Triggers: push to `master`, weekly cron **Mondays 02:00 UTC**, and manual
+  `workflow_dispatch`. The weekly cron exists so the image regularly picks up
+  fresh ARK/Steam/base-image state — keep it.
+- Resolves the current ark-server-tools master commit at build time and passes
+  it as `ARK_TOOLS_VERSION` (this is where `tools-<sha>` comes from).
+- Uses `docker/login-action`, `docker/metadata-action`,
+  `docker/build-push-action`; concurrency-guarded per ref.
+
+**Build PR Preview** (`deploy-preview.yml`):
+
+- Triggers on `pull_request` against `master`; concurrency-guarded per PR.
+- **Fork-safe:** fork PRs build for validation only — they never receive
+  secrets and never push. Same-repo PRs push `pr-<n>`, and only if the
+  registry secrets are actually configured (the eligibility step checks for
+  `DOCKERHUB_TOKEN`). Keep this property when editing the workflow.
+
+**Required repository secrets:**
+
+| Secret | Used for |
+|---|---|
+| `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` | Docker Hub |
+| `QUAY_USERNAME` / `QUAY_TOKEN` | Quay.io |
+| — (built-in `GITHUB_TOKEN`, `permissions: packages: write`) | GHCR |
+
+## Invariants — do not "optimize" these away
+
+- **`no-cache: true` + `pull: true` is intentional.** Every publish must
+  rebuild from scratch on a freshly pulled base so it captures current
+  ARK/steamcmd state. Adding layer caching would silently ship stale servers.
+- **`linux/amd64` only.** The base image and the ARK dedicated server are
+  x86-only. Do not add arm64 builds or QEMU emulation — they cannot work.
+- **arkmanager default pin.** `Dockerfile` pins
+  `ARG ARK_TOOLS_VERSION="v1.6.69"` so local/manual builds are deterministic.
+  The Dockerfile picks `--tag` vs `--commit` for `netinstall.sh` based on a
+  leading `v`. CI overrides the ARG with a resolved commit SHA at build time.
+- Keep entrypoint/runtime behavior and documented environment variables
+  backward compatible; users run long-lived servers against `latest`.
+
+## Common tasks
+
+- **Bump the arkmanager pin:** check
+  `gh api repos/arkmanager/ark-server-tools/releases/latest --jq .tag_name`,
+  update the `ARK_TOOLS_VERSION` ARG default in `Dockerfile`, PR it.
+- **Action version updates:** Dependabot opens weekly PRs; review the
+  changelog, merge. The PR preview build doubles as the smoke test.
+- **Scheduled workflow got disabled?** GitHub disables cron workflows after
+  ~60 days without repository activity. Re-enable with
+  `gh workflow enable "Build and Publish"` (or via the Actions tab), then
+  `gh workflow run "Build and Publish"` for an immediate build.
+- **Manual release:** `gh workflow run "Build and Publish"` on `master`.
+
+## Known follow-ups / out of scope
+
+- **ARK: Survival Ascended (ASA)** is deliberately not supported here — it has
+  a different server (Windows/Proton-based) and would be a separate image, not
+  a feature flag in this one.
+- The old `DOCKER_CONFIG_JSON` secret is unused since the CI modernization and
+  can be deleted once the per-registry secrets are in place.
+
+## Note for Windows contributors
+
+`CLAUDE.md` is a git symlink to `AGENTS.md` (index mode `120000`). On Windows
+checkouts without symlink support it materializes as a plain text file whose
+content is just `AGENTS.md` — that is expected. Never re-stage that file with
+`git add CLAUDE.md` from such a checkout: it would replace the symlink with a
+regular file. Edit `AGENTS.md` only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM        cm2network/steamcmd:root
 
 LABEL       MAINTAINER="https://github.com/Hermsi1337/"
 
-ARG         ARK_TOOLS_VERSION="8ddf0b83dc82243d8fc9ecf9bf4bac62c6911c73"
+ARG         ARK_TOOLS_VERSION="v1.6.69"
 ARG         IMAGE_VERSION="dev"
 
 ENV         IMAGE_VERSION="${IMAGE_VERSION}" \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Gitlab pipeline status](https://img.shields.io/gitlab/pipeline-status/hermsi1337/docker-ark-server?branch=master&style=flat-square)
+[![Build and Publish](https://github.com/Hermsi1337/docker-ark-server/actions/workflows/build-and-deploy.yml/badge.svg)](https://github.com/Hermsi1337/docker-ark-server/actions/workflows/build-and-deploy.yml)
 [![Docker Pulls](https://img.shields.io/docker/pulls/hermsi/ark-server?label=hub.docker.com%20pulls&style=flat-square)](https://hub.docker.com/r/hermsi/ark-server)
 [![Docker Repository on Quay](https://img.shields.io/badge/Quay.io-Repository-blue)](https://quay.io/repository/hermsi1337/ark-server)
 [![Donate](https://img.shields.io/badge/Donate-PayPal-blue.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=T85UYT37P3YNJ&source=url)
@@ -60,8 +60,6 @@ $ docker run -d --name="ark_server" --restart=always -v "${HOME}/ark-server:/app
 
 In order to startup your own ARK-server with `docker-compose` - which I personally preffer over a simple `docker run` - you may adapt the following `docker-compose.yml`:
 ```yml
-version: '3'
-
 services:
   server:
     restart: always
@@ -102,7 +100,7 @@ $ docker-compose up -d
 
 After your container is up and ARK is installed you can start tweaking your configuration.   
 Basically, you can modify every setting which ARK-Server-Tools are capable of.   
-For reference of the available commands check [their docs](https://github.com/FezVrasta/ark-server-tools#configuration).   
+For reference of the available commands check [their docs](https://github.com/arkmanager/ark-server-tools#configuration).   
 
 The main config files are located at the following path in the container:
 
@@ -119,7 +117,7 @@ $ docker exec -u steam ark_server arkmanager update --force
 $ docker exec -u steam ark_server arkmanager installmods
 ```
 
-For a full list of all available commands [check here](https://github.com/FezVrasta/ark-server-tools#commands-acting-on-instances)
+For a full list of all available commands [check here](https://github.com/arkmanager/ark-server-tools#commands-acting-on-instances)
 
 ### Add cronjobs
 


### PR DESCRIPTION
## What

Modernizes the GitHub Actions CI without changing what it ships. The image
(`hermsi/ark-server`), the ARK: Survival Evolved / steamcmd + arkmanager stack,
the `cm2network/steamcmd:root` base, the `linux/amd64`-only target, and the
`--pull --no-cache` behaviour all stay exactly as they were.

- **Official Docker actions** replace the raw `docker build` / `docker push`
  calls and the hand-written `DOCKER_CONFIG_JSON` file: `docker/login-action`,
  `docker/metadata-action`, `docker/build-push-action`, plus current majors of
  `actions/checkout` (v7) and `docker/setup-buildx-action` (v4).
- **Unique workflow names.** Both workflows were previously named
  "Build and Deploy Docker". They are now **Build and Publish**
  (`build-and-deploy.yml`) and **Build PR Preview** (`deploy-preview.yml`).
- **Dead code removed.** The `pr_publish` job in `build-and-deploy.yml` could
  never run (that workflow has no `pull_request` trigger). PR preview logic now
  lives only in `deploy-preview.yml`.
- **Tag schema preserved exactly:** `latest`, `latest-<timestamp>`,
  `tools-<sha>`, and PR previews `pr-<n>`.
- **Triggers preserved:** weekly cron (Mondays 02:00 UTC), push to the default
  branch, and `workflow_dispatch`.
- **GHCR added** as a third registry (`ghcr.io/hermsi1337/ark-server`),
  authenticated with the built-in `GITHUB_TOKEN` (`permissions: packages: write`).
- **Fork-safe previews.** `deploy-preview.yml` runs on `pull_request`; fork PRs
  build for validation only and never touch secrets. Only same-repo PRs log in
  and push `pr-<n>`.
- **Concurrency guards** on both workflows and a weekly **Dependabot**
  (`github-actions`) config.
- **Dockerfile:** the default `ARK_TOOLS_VERSION` build arg is pinned to the
  latest ark-server-tools release tag **v1.6.69** (was an arbitrary commit SHA),
  so local/manual builds are deterministic. CI still resolves and overrides the
  value at build time, so `tools-<sha>` tags are unchanged. Entrypoint/runtime
  behaviour is untouched.
- **README:** dead GitLab badge replaced with a GHA build badge, `FezVrasta`
  tool links repointed to `arkmanager/ark-server-tools`, and the obsolete
  `version:` key dropped from the compose example.

## Why

The workflows relied on manual Docker CLI plumbing and a raw secret blob, carried
a job that never executed, and shipped two identically named pipelines. The
README pointed at a dead badge and an abandoned upstream fork.

## Required secrets before merge

The workflows switch from the single `DOCKER_CONFIG_JSON` secret to per-registry
username/token pairs. **These do not exist yet and must be created before this
merges**, otherwise the publish job will fail to log in:

| Secret | Purpose |
|---|---|
| `DOCKERHUB_USERNAME` | Docker Hub login for `hermsi/ark-server` |
| `DOCKERHUB_TOKEN` | Docker Hub access token |
| `QUAY_USERNAME` | Quay.io login for `quay.io/hermsi1337/ark-server` |
| `QUAY_TOKEN` | Quay.io access token / password |

GHCR uses the automatic `GITHUB_TOKEN`; no secret needed. The old
`DOCKER_CONFIG_JSON` secret is no longer referenced and can be deleted after merge.

## What happens after merge

- On push to `master`, weekly on Mondays at 02:00 UTC, and via manual
  `workflow_dispatch`, the **Build and Publish** workflow builds
  `linux/amd64` with `--pull --no-cache` and pushes `latest`,
  `latest-<timestamp>`, and `tools-<sha>` to Docker Hub, Quay.io, and GHCR.
- Pull requests trigger **Build PR Preview**; same-repo PRs publish `pr-<n>` to
  all three registries, fork PRs build only.
- Dependabot opens weekly PRs to keep the action versions current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
