### PR TITLE
fix: gracefully stop the server on docker stop/restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Basic configuration is done with environment variables:
 | GAME_MOD_IDS | `empty` | Additional game mods to install, separated by comma (e.g. `GAME_MOD_IDS=487516323,487516324,487516325`) |
 | UPDATE_ON_START | false | Update the ARK server and mods (with a backup, if configured) before each start |
 | PRE_UPDATE_BACKUP | true | Create a backup before updating the ARK server |
-| BACKUP_ON_STOP * | false | Create a backup before gracefully stopping the ARK server |
-| WARN_ON_STOP * | true | Broadcast a warning upon graceful shutdown |
+| BACKUP_ON_STOP | false | Create a backup after the world save when the container is stopped gracefully |
+| WARN_ON_STOP | true | Broadcast a shutdown warning to players when the container is stopped gracefully |
 | ENABLE_CROSSPLAY | false | Enable crossplay (starts the server with `-crossplay`). When enabled, BattlEye should be disabled as it likes to disconnect Epic players |
 | DISABLE_BATTLEYE | false | Disable BattlEye protection (starts the server with `-NoBattlEye`) |
 | BETA | `empty` | Opt into a Steam beta branch if necessary (e.g. `BETA=preaquatica`) |
@@ -134,10 +134,22 @@ Basic configuration is done with environment variables:
 | SERVER_LIST_PORT | 27015 | Exposed server-list (query) port |
 | DEBUG | `empty` | Set to `true` for verbose (`set -x`) entrypoint logging |
 
-\* `BACKUP_ON_STOP` and `WARN_ON_STOP` are accepted for backwards
-compatibility but are currently not evaluated by the entrypoint or the bundled
-arkmanager configuration. Use a [cronjob](#add-cronjobs) or
-`arkmanager backup` for scheduled backups instead.
+### Graceful shutdown
+
+On `docker stop` / `docker restart` the entrypoint warns players
+(`WARN_ON_STOP`), saves the world via `arkmanager stop --saveworld` and
+optionally creates a backup (`BACKUP_ON_STOP`). Docker only waits 10 seconds
+by default before force-killing the container — far too short for an ARK
+world save. Raise the grace period, otherwise you risk losing progress:
+
+```yaml
+services:
+  server:
+    stop_grace_period: 5m
+```
+
+For plain `docker` commands use `docker stop -t 300 ark-server` (and
+`docker run --stop-timeout 300 ...`).
 
 ### Data layout
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ services:
 For plain `docker` commands use `docker stop -t 300 ark-server` (and
 `docker run --stop-timeout 300 ...`).
 
+Note: the world save itself is additionally bounded by arkmanager-internal
+timeouts (roughly 50 seconds) — the grace period has to cover the shutdown
+warning, the save, the optional backup and the process shutdown.
+
 ### Data layout
 
 Everything the server needs lives in the volume mounted at `/app`

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -21,6 +21,24 @@ function may_update() {
   ${ARKMANAGER} update --verbose --update-mods --backup --no-autostart ${BETA_ARGS[@]}
 }
 
+function stop_server() {
+  echo "Caught stop signal, gracefully stopping the ARK server..."
+
+  if [[ "${WARN_ON_STOP}" == "true" ]]; then
+    ${ARKMANAGER} broadcast "Server is shutting down" || true
+  fi
+
+  ${ARKMANAGER} stop --saveworld || echo "Graceful stop failed, the server may not have saved!"
+
+  if [[ "${BACKUP_ON_STOP}" == "true" ]]; then
+    echo "\$BACKUP_ON_STOP is 'true', creating a backup..."
+    ${ARKMANAGER} backup || echo "Backup on stop failed, continuing shutdown..."
+  fi
+
+  [[ -z "${ARK_RUN_PID}" ]] || wait "${ARK_RUN_PID}" || true
+  exit 0
+}
+
 function create_missing_dir() {
   for DIRECTORY in ${@}; do
     [[ -n "${DIRECTORY}" ]] || return
@@ -148,4 +166,13 @@ fi
 
 may_update
 
-exec "${ARKMANAGER}" run --verbose ${args[@]}
+# Run the server in the background and wait for it, so that this script stays
+# PID 1 and can react to docker stop/restart: without this, the container is
+# killed without a world save and players lose progress (#38).
+# Docker's default grace period of 10s is far too short for an ARK world save,
+# so raise it (docker stop -t / stop_grace_period) as documented in the README.
+trap stop_server TERM INT
+
+"${ARKMANAGER}" run --verbose ${args[@]} &
+ARK_RUN_PID=$!
+wait "${ARK_RUN_PID}"

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -9,6 +9,11 @@ if [[ "$(whoami)" != "${STEAM_USER}" ]]; then
   exit 1
 fi
 
+# minimal stop handler for the install/update phase: bash as PID 1 would
+# otherwise ignore SIGTERM entirely; replaced by stop_server once the
+# server is about to run
+trap 'exit 143' TERM INT
+
 function may_update() {
   if [[ "${UPDATE_ON_START}" != "true" ]]; then
     return
@@ -33,6 +38,12 @@ function stop_server() {
   if [[ "${BACKUP_ON_STOP}" == "true" ]]; then
     echo "\$BACKUP_ON_STOP is 'true', creating a backup..."
     ${ARKMANAGER} backup || echo "Backup on stop failed, continuing shutdown..."
+  fi
+
+  # if the run process is still alive (e.g. the signal arrived before the
+  # server pidfile existed, so stop had nothing to do), terminate it directly
+  if [[ -n "${ARK_RUN_PID}" ]] && kill -0 "${ARK_RUN_PID}" 2>/dev/null; then
+    kill -TERM "${ARK_RUN_PID}" 2>/dev/null || true
   fi
 
   [[ -z "${ARK_RUN_PID}" ]] || wait "${ARK_RUN_PID}" || true

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     restart: always
     container_name: ${COMPOSE_PROJECT_NAME}_server
     image: hermsi/ark-server:latest
+    # Give the server enough time to broadcast, save the world and shut down
+    # gracefully before docker sends SIGKILL (default would be 10s)
+    stop_grace_period: 5m
     # If you want to build from fresh source every "docker-compose up" ...
     # ... remove the "image:"-key and uncomment the following two lines:
     #build:


### PR DESCRIPTION
## Problem

`docker stop` / `docker restart` killed the ARK server **without a world save** — players lost inventory and progress (multiple confirmed reports over the years, including containers auto-restarted by watchtower). Root cause: since a0fcb14 (April 2021) the entrypoint `exec`'d straight into `arkmanager run` with no signal handling, and the documented `BACKUP_ON_STOP` / `WARN_ON_STOP` variables were referenced nowhere in the codebase.

## Fix

- `steam-entrypoint.sh` stays PID 1, runs `arkmanager run` in the background and traps `SIGTERM`/`SIGINT`.
- On stop it now: broadcasts a shutdown warning (`WARN_ON_STOP=true`, default) → `arkmanager stop --saveworld` → optionally creates a backup of the just-saved world (`BACKUP_ON_STOP=true`).
- `deploy/docker-compose.yml` sets `stop_grace_period: 5m` — Docker's default of 10 s is far too short for an ARK world save and would SIGKILL mid-save.
- README: the two variables are documented as functional again (the previous footnote declared them unused), plus a new *Graceful shutdown* section explaining the grace period.

Note on #123: instead of deleting the two dead variables, this restores the behavior they always documented. The second suggestion in #123 (hard-wiring `ARK_SERVER_VOLUME` to `/app`) is intentionally not done — it is a documented, long-standing configuration knob and removing it would break existing setups.

Closes #38
Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)