### PR TITLE
fix: make cron jobs actually work (environment + NAS permissions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,17 @@ Add your desired cronjobs with valid syntax (they run as the `steam` user):
 0 0 * * * arkmanager backup >> /app/log/crontab.log 2>&1
 ```
 
+The container environment is exported to `/app/environment` on every start and
+loaded into each job via the crontab's `BASH_ENV` header, so cron jobs see the
+same variables as the server process. If your crontab was created by an older
+image and jobs fail with errors like `mkdir: cannot create directory '/server'`,
+add these two lines at the top of the file:
+
+```bash
+SHELL=/bin/bash
+BASH_ENV=/app/environment
+```
+
 The crontab is loaded when the container starts, so apply your changes with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Everything the server needs lives in the volume mounted at `/app`
 | `/app/log` | arkmanager log files |
 | `/app/staging` | Staging directory for server updates |
 | `/app/crontab` | Cron definitions loaded at container start |
+| `/app/environment` | Auto-generated on every start: container environment for cron jobs (contains credentials, mode 600) |
 | `/app/arkmanager` | Persisted arkmanager configuration (global + instance) |
 | `/app/Game.ini`, `/app/GameUserSettings.ini` | Convenience symlinks to the real config files |
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -26,6 +26,8 @@ ln -s "${ARK_TOOLS_DIR}" "/etc/arkmanager"
 # containers with no-new-privileges (e.g. some NAS systems).
 if [[ ! -f "${ARK_SERVER_VOLUME}/crontab" ]]; then
   cp -a "${TEMPLATE_DIRECTORY}/crontab" "${ARK_SERVER_VOLUME}/crontab"
+  # the template defaults to /app - point BASH_ENV at the actual volume path
+  sed -i "s|^BASH_ENV=.*|BASH_ENV=${ARK_SERVER_VOLUME}/environment|" "${ARK_SERVER_VOLUME}/crontab"
   chown "${STEAM_USER}": "${ARK_SERVER_VOLUME}/crontab" || true
 fi
 crontab -u "${STEAM_USER}" "${ARK_SERVER_VOLUME}/crontab" || echo "Failed loading crontab, continuing startup..."

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -21,6 +21,15 @@ chown -R "${STEAM_USER}": "${ARK_TOOLS_DIR}" || echo "Failed setting rights on $
 rm -rf "/etc/arkmanager"
 ln -s "${ARK_TOOLS_DIR}" "/etc/arkmanager"
 
+# Copy the crontab template on first start and load it as root: the setgid
+# crontab binary fails with "mkstemp: Permission denied" on hosts that run
+# containers with no-new-privileges (e.g. some NAS systems).
+if [[ ! -f "${ARK_SERVER_VOLUME}/crontab" ]]; then
+  cp -a "${TEMPLATE_DIRECTORY}/crontab" "${ARK_SERVER_VOLUME}/crontab"
+  chown "${STEAM_USER}": "${ARK_SERVER_VOLUME}/crontab" || true
+fi
+crontab -u "${STEAM_USER}" "${ARK_SERVER_VOLUME}/crontab" || echo "Failed loading crontab, continuing startup..."
+
 service cron start
 
 exec gosu "${STEAM_USER}" /steam-entrypoint.sh $*

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -127,13 +127,18 @@ ARKMANAGER="$(command -v arkmanager)"
 
 cd "${ARK_SERVER_VOLUME}"
 
+# export the container environment for cron jobs: the bundled crontab loads it
+# via BASH_ENV so that arkmanager and its bash-based config files see the same
+# variables as the server process
+export -p > "${ARK_SERVER_VOLUME}/environment"
+chmod 600 "${ARK_SERVER_VOLUME}/environment"
+
 echo "Setting up folder and file structure..."
 create_missing_dir "${ARK_SERVER_VOLUME}/log" "${ARK_SERVER_VOLUME}/backup" "${ARK_SERVER_VOLUME}/staging"
 
 # copy from template to server volume
 copy_missing_file "${TEMPLATE_DIRECTORY}/arkmanager.cfg" "${ARK_TOOLS_DIR}/arkmanager.cfg"
 copy_missing_file "${TEMPLATE_DIRECTORY}/arkmanager-user.cfg" "${ARK_TOOLS_DIR}/instances/main.cfg"
-copy_missing_file "${TEMPLATE_DIRECTORY}/crontab" "${ARK_SERVER_VOLUME}/crontab"
 
 [[ -L "${ARK_SERVER_VOLUME}/Game.ini" ]] ||
   ln -s ./server/ShooterGame/Saved/Config/LinuxServer/Game.ini Game.ini
@@ -156,8 +161,6 @@ if needs_install; then
     exit 1
   fi
 fi
-
-crontab "${ARK_SERVER_VOLUME}/crontab"
 
 if [[ -n "${GAME_MOD_IDS}" ]]; then
   echo "Installing mods: '${GAME_MOD_IDS}' ..."

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -127,11 +127,11 @@ ARKMANAGER="$(command -v arkmanager)"
 
 cd "${ARK_SERVER_VOLUME}"
 
-# export the container environment for cron jobs: the bundled crontab loads it
-# via BASH_ENV so that arkmanager and its bash-based config files see the same
-# variables as the server process
-export -p > "${ARK_SERVER_VOLUME}/environment"
-chmod 600 "${ARK_SERVER_VOLUME}/environment"
+# export the container environment for cron jobs (minus shell bookkeeping):
+# the bundled crontab loads it via BASH_ENV so that arkmanager and its
+# bash-based config files see the same variables as the server process
+export -p | grep -Ev '^declare -x (PWD|OLDPWD|SHLVL)($|=)' > "${ARK_SERVER_VOLUME}/environment"
+chmod 600 "${ARK_SERVER_VOLUME}/environment" || echo "Failed to restrict permissions on ${ARK_SERVER_VOLUME}/environment, continuing startup..."
 
 echo "Setting up folder and file structure..."
 create_missing_dir "${ARK_SERVER_VOLUME}/log" "${ARK_SERVER_VOLUME}/backup" "${ARK_SERVER_VOLUME}/staging"

--- a/conf.d/crontab
+++ b/conf.d/crontab
@@ -1,3 +1,11 @@
+# Cron jobs run with an almost empty environment. The two lines below make
+# every job run through bash and load the container environment (written to
+# /app/environment by the entrypoint on every start), so that arkmanager and
+# its bash-based config files behave exactly like in the server process.
+# If you changed ARK_SERVER_VOLUME, adjust the BASH_ENV path accordingly.
+SHELL=/bin/bash
+BASH_ENV=/app/environment
+#
 # Example of job definition:
 # .---------------- minute (0 - 59)
 # |  .------------- hour (0 - 23)
@@ -5,12 +13,14 @@
 # |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
 # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
 # |  |  |  |  |
-# *  *  *  *  *  user command to be executed
-# WARNING : the container timezone is maybe not your current timezone
+# *  *  *  *  *  command to be executed
+#
+# WARNING : the container timezone may not match your host timezone.
 #           You can sync them with option -v /etc/localtime:/etc/localtime:ro or -e "TZ=UTC"
-# Example : update every hour
-# 0 * * * * su -c "arkmanager backup" steam 2>&1
+#
+# Example : update every day at 4am
+# 0 4 * * * arkmanager update --warn --update-mods >> /app/log/crontab.log 2>&1
 # Example : backup every 15min
-# */15 * * * * su -c "arkmanager backup" steam 2>&1
+# */15 * * * * arkmanager backup >> /app/log/crontab.log 2>&1
 # Example : backup every day at midnight
-# 0 0 * * * su -c "arkmanager backup" steam 2>&1
+# 0 0 * * * arkmanager backup >> /app/log/crontab.log 2>&1


### PR DESCRIPTION
Cron-based backups/updates were broken in **two independent ways**:

## 1. Cron jobs did not see the container environment (#9)

arkmanager's config files are bash-sourced and reference `${ARK_SERVER_VOLUME}`, `${STEAM_HOME}` etc. Under cron those resolve to empty strings, producing exactly the errors reported in #9:

```
mkdir: cannot create directory '/server': Permission denied
[  ERROR  ] The ARK SavedArks directory is not writable, and saveworld will fail
```

**Fix:** the entrypoint now exports the container environment to `/app/environment` (mode 600) on every start, and the bundled crontab loads it into every job via a `BASH_ENV` header — the approach that was community-proven in the #9 thread back in 2021. Cron examples now just work as plain `arkmanager backup` lines; the broken `su -c "..." steam` examples (which prompt for a password when run from the steam user's own crontab) are gone.

## 2. Loading the crontab failed on NAS systems (#116)

`crontab` relies on a setgid binary. On hosts that run containers with `no-new-privileges` (UGREEN, Synology, …) that fails with:

```
/var/spool/cron/: mkstemp: Permission denied
```

**Fix:** the crontab (template copy + load) moved into `docker-entrypoint.sh` and is installed as **root** via `crontab -u steam` before privileges are dropped — no setgid needed. Jobs still run as the `steam` user.

## Notes for existing volumes

The crontab file in existing volumes is user data and is not touched. The README documents the two `SHELL`/`BASH_ENV` header lines users should add to a pre-existing crontab.

Closes #9
Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)