### PR TITLE
fix: verify the installation and fail loudly instead of exit 0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ENV         IMAGE_VERSION="${IMAGE_VERSION}" \
             BACKUP_ON_STOP="false" \
             PRE_UPDATE_BACKUP="true" \
             WARN_ON_STOP="true" \
+            SKIP_DISK_CHECK="false" \
             ARK_TOOLS_VERSION="${ARK_TOOLS_VERSION}" \
             ARK_SERVER_VOLUME="/app" \
             BETA="" \

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Basic configuration is done with environment variables:
 | UDP_SOCKET_PORT | 7778 | Raw UDP socket port (always game client port +1) |
 | RCON_PORT | 27020 | Exposed RCON port |
 | SERVER_LIST_PORT | 27015 | Exposed server-list (query) port |
+| SKIP_DISK_CHECK | false | Skip the free-disk-space check (~25GB) before the initial server installation |
 | DEBUG | `empty` | Set to `true` for verbose (`set -x`) entrypoint logging |
 
 ### Graceful shutdown

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -72,21 +72,23 @@ function copy_missing_file() {
 
 function needs_install() {
   local SERVER_DIR="${ARK_SERVER_VOLUME}/server"
+  local SERVER_EXEC="${SERVER_DIR}/ShooterGame/Binaries/Linux/ShooterGameServer"
   if [ ! -d "${SERVER_DIR}" ]; then
     echo "${SERVER_DIR} not found ..."
     return 0
   fi
 
-  # Backwards compatibility
+  # Backwards compatibility - but only trust version.txt if the server
+  # executable actually exists, otherwise trigger a repair install
   local VERSION_FILE="${SERVER_DIR}/version.txt"
-  if [ -f "${VERSION_FILE}" ]; then
+  if [ -f "${VERSION_FILE}" ] && [ -s "${SERVER_EXEC}" ]; then
     echo "Already installed. (found ${VERSION_FILE})"
     return 1
   fi
 
   local INSTALLED_FILES=(
     "${SERVER_DIR}/steamapps/appmanifest_376030.acf"
-    "${SERVER_DIR}/ShooterGame/Binaries/Linux/ShooterGameServer"
+    "${SERVER_EXEC}"
   )
   for FILE in "${INSTALLED_FILES[@]}"; do
     if [ ! -s "${FILE}" ]; then
@@ -97,6 +99,24 @@ function needs_install() {
 
   echo "Already installed."
   return 1
+}
+
+function assert_free_disk_space() {
+  # a fresh ARK install needs roughly 25GB (plus staging/backup headroom)
+  local REQUIRED_MB="25000"
+  local AVAILABLE_MB
+
+  if [[ "${SKIP_DISK_CHECK}" == "true" ]]; then
+    return
+  fi
+
+  AVAILABLE_MB="$(df -Pm "${ARK_SERVER_VOLUME}" | awk 'NR==2 {print $4}')"
+  if [[ -n "${AVAILABLE_MB}" ]] && (( AVAILABLE_MB < REQUIRED_MB )); then
+    echo "ERROR: Not enough free disk space on ${ARK_SERVER_VOLUME}:"
+    echo "       ${AVAILABLE_MB}MB available, ~${REQUIRED_MB}MB required for the ARK server files."
+    echo "       Free up disk space, or set SKIP_DISK_CHECK=true to install anyway."
+    exit 1
+  fi
 }
 
 args=("$*")
@@ -148,6 +168,8 @@ copy_missing_file "${TEMPLATE_DIRECTORY}/arkmanager-user.cfg" "${ARK_TOOLS_DIR}/
 if needs_install; then
   echo "No game files found. Installing..."
 
+  assert_free_disk_space
+
   create_missing_dir \
     "${ARK_SERVER_VOLUME}/server/ShooterGame/Saved/SavedArks" \
     "${ARK_SERVER_VOLUME}/server/ShooterGame/Content/Mods" \
@@ -157,7 +179,17 @@ if needs_install; then
   chmod +x "${ARK_SERVER_VOLUME}/server/ShooterGame/Binaries/Linux/ShooterGameServer"
 
   if ! ${ARKMANAGER} install --verbose ${BETA_ARGS[@]}; then
-    echo "Installation failed"
+    echo "ERROR: Installation failed - check the steamcmd output above."
+    echo "       Common causes: not enough disk space ($(df -Ph "${ARK_SERVER_VOLUME}" | awk 'NR==2 {print $4}') left on ${ARK_SERVER_VOLUME}), network hiccups."
+    exit 1
+  fi
+
+  # steamcmd occasionally reports success although the download is incomplete
+  # (e.g. 'state is 0x202 after update job' on full disks) - verify it
+  if needs_install > /dev/null; then
+    echo "ERROR: Installation finished but the server files are still incomplete."
+    echo "       Check the steamcmd output above and the free disk space on ${ARK_SERVER_VOLUME}"
+    echo "       ($(df -Ph "${ARK_SERVER_VOLUME}" | awk 'NR==2 {print $4}') left), then restart the container to retry."
     exit 1
   fi
 fi

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -110,6 +110,12 @@ function assert_free_disk_space() {
     return
   fi
 
+  # repair installs already have most content on disk and steamcmd validate
+  # only fetches what is missing - the full-size gate is for fresh installs
+  if [[ -d "${ARK_SERVER_VOLUME}/server/ShooterGame" ]]; then
+    return
+  fi
+
   AVAILABLE_MB="$(df -Pm "${ARK_SERVER_VOLUME}" | awk 'NR==2 {print $4}')"
   if [[ -n "${AVAILABLE_MB}" ]] && (( AVAILABLE_MB < REQUIRED_MB )); then
     echo "ERROR: Not enough free disk space on ${ARK_SERVER_VOLUME}:"
@@ -186,7 +192,8 @@ if needs_install; then
 
   # steamcmd occasionally reports success although the download is incomplete
   # (e.g. 'state is 0x202 after update job' on full disks) - verify it
-  if needs_install > /dev/null; then
+  if VERIFY_OUTPUT="$(needs_install)"; then
+    echo "${VERIFY_OUTPUT}"
     echo "ERROR: Installation finished but the server files are still incomplete."
     echo "       Check the steamcmd output above and the free disk space on ${ARK_SERVER_VOLUME}"
     echo "       ($(df -Ph "${ARK_SERVER_VOLUME}" | awk 'NR==2 {print $4}') left), then restart the container to retry."


### PR DESCRIPTION
## Problem

When steamcmd runs out of disk space during the ~25GB initial download, it ends with `Error! App '376030' state is 0x202 after update job` — but the container happily proceeded to `arkmanager run`, printed `Your ARK server exec could not be found` and **exited with status 0**. Docker treats that as a graceful exit, so there was no restart-loop signal and no hint at the actual cause (#74). Volumes with a legacy `version.txt` but a broken/missing `ShooterGameServer` binary got stuck in exactly this state forever, because the installer never re-ran (#103).

## Fix

- **Pre-install disk check:** before a fresh install the entrypoint verifies ~25GB of free space on `ARK_SERVER_VOLUME` and aborts with an actionable message otherwise. Override with `SKIP_DISK_CHECK=true` (documented in the README).
- **Post-install verification:** after `arkmanager install` the entrypoint re-checks that the server files are actually complete and exits 1 with a disk-space hint if not — no more silent exit 0.
- **Self-repair for broken installs:** the legacy `version.txt` marker is only trusted when the `ShooterGameServer` binary actually exists. Otherwise the install runs again, which is incremental via steamcmd validate — broken volumes repair themselves on the next restart.

Closes #74
Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)