### PR TITLE
feat: add VALIDATE_ON_START to repair server files via steamcmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV         IMAGE_VERSION="${IMAGE_VERSION}" \
             MAX_PLAYERS="20" \
             GAME_MOD_IDS="" \
             UPDATE_ON_START="false" \
+            VALIDATE_ON_START="false" \
             BACKUP_ON_STOP="false" \
             PRE_UPDATE_BACKUP="true" \
             WARN_ON_STOP="true" \

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Basic configuration is done with environment variables:
 | MAX_PLAYERS | 20 | Maximum number of players in your session |
 | GAME_MOD_IDS | `empty` | Additional game mods to install, separated by comma (e.g. `GAME_MOD_IDS=487516323,487516324,487516325`) |
 | UPDATE_ON_START | false | Update the ARK server and mods (with a backup, if configured) before each start |
+| VALIDATE_ON_START | false | Let `steamcmd` validate and repair the server files during `UPDATE_ON_START` — useful after a corrupted update, but makes the start noticeably slower |
 | PRE_UPDATE_BACKUP | true | Create a backup before updating the ARK server |
 | BACKUP_ON_STOP | false | Create a backup after the world save when the container is stopped gracefully |
 | WARN_ON_STOP | true | Broadcast a shutdown warning to players when the container is stopped gracefully |

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -21,9 +21,17 @@ function may_update() {
 
   echo "\$UPDATE_ON_START is 'true'..."
 
+  local UPDATE_ARGS=(--verbose --update-mods --backup --no-autostart)
+  # let steamcmd validate and repair the installed files, e.g. after a
+  # corrupted download - slower, therefore opt-in
+  if [[ "${VALIDATE_ON_START}" == "true" ]]; then
+    echo "\$VALIDATE_ON_START is 'true'..."
+    UPDATE_ARGS+=(--validate)
+  fi
+
   # auto checks if a update is needed, if yes, then update the server or mods
   # (otherwise it just does nothing)
-  ${ARKMANAGER} update --verbose --update-mods --backup --no-autostart ${BETA_ARGS[@]}
+  ${ARKMANAGER} update "${UPDATE_ARGS[@]}" ${BETA_ARGS[@]}
 }
 
 function stop_server() {

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -16,6 +16,8 @@ trap 'exit 143' TERM INT
 
 function may_update() {
   if [[ "${UPDATE_ON_START}" != "true" ]]; then
+    [[ "${VALIDATE_ON_START}" != "true" ]] ||
+      echo "WARNING: VALIDATE_ON_START has no effect because UPDATE_ON_START is not 'true' - skipping validation"
     return
   fi
 


### PR DESCRIPTION
## Problem

When an update corrupts the installation, users are stranded: `arkmanager update` reports *'Your server is already up to date!'* and does nothing, while the server core-dumps on start. The reporter of #82 had to edit `steam-entrypoint.sh` by hand to pass `--validate` — and the issue has been waiting for exactly this flag since 2022.

## Fix

New opt-in env var:

| Variable | Default | Effect |
|---|---|---|
| `VALIDATE_ON_START` | `false` | When `true`, the `UPDATE_ON_START` update runs with `--validate`, letting steamcmd verify and repair all installed files |

Validation is incremental (only corrupt/missing chunks are re-downloaded) but still noticeably slows down the start — hence opt-in: set it to `true` once, restart, turn it back off.

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)