### PR TITLE
fix: self-heal Game.ini/GameUserSettings.ini symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ The main game config files are located at:
 
 The entrypoint symlinks both of them into the volume root, so on the host you
 can simply edit `<your-volume>/Game.ini` and `<your-volume>/GameUserSettings.ini`.
+If an upload replaces one of these symlinks with a regular file, the entrypoint
+adopts the uploaded content as the real config on the next start (keeping the
+previous one as `.bak`) and re-creates the symlink.
 
 The arkmanager configuration (`arkmanager.cfg` and the `main` instance config)
 persists in `<your-volume>/arkmanager/`. The bundled templates are only copied

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -166,10 +166,24 @@ create_missing_dir "${ARK_SERVER_VOLUME}/log" "${ARK_SERVER_VOLUME}/backup" "${A
 copy_missing_file "${TEMPLATE_DIRECTORY}/arkmanager.cfg" "${ARK_TOOLS_DIR}/arkmanager.cfg"
 copy_missing_file "${TEMPLATE_DIRECTORY}/arkmanager-user.cfg" "${ARK_TOOLS_DIR}/instances/main.cfg"
 
-[[ -L "${ARK_SERVER_VOLUME}/Game.ini" ]] ||
-  ln -s ./server/ShooterGame/Saved/Config/LinuxServer/Game.ini Game.ini
-[[ -L "${ARK_SERVER_VOLUME}/GameUserSettings.ini" ]] ||
-  ln -s ./server/ShooterGame/Saved/Config/LinuxServer/GameUserSettings.ini GameUserSettings.ini
+# Game.ini and GameUserSettings.ini in the volume root are convenience
+# symlinks to the real config files. Users regularly replace them with
+# regular files by accident (e.g. via SFTP upload) - in that case adopt the
+# uploaded content as the real config and re-create the symlink, instead of
+# dying on 'ln: File exists'.
+CONFIG_DIR="./server/ShooterGame/Saved/Config/LinuxServer"
+for INI_FILE in Game.ini GameUserSettings.ini; do
+  INI_LINK="${ARK_SERVER_VOLUME}/${INI_FILE}"
+  if [[ -e "${INI_LINK}" ]] && [[ ! -L "${INI_LINK}" ]]; then
+    echo "${INI_LINK} is a regular file but should be a symlink to ${CONFIG_DIR}/${INI_FILE} - fixing..."
+    mkdir -p "${CONFIG_DIR}"
+    if [[ -f "${CONFIG_DIR}/${INI_FILE}" ]]; then
+      cp -a "${CONFIG_DIR}/${INI_FILE}" "${CONFIG_DIR}/${INI_FILE}.bak"
+    fi
+    mv -f "${INI_LINK}" "${CONFIG_DIR}/${INI_FILE}"
+  fi
+  [[ -L "${INI_LINK}" ]] || ln -s "${CONFIG_DIR}/${INI_FILE}" "${INI_FILE}"
+done
 
 if needs_install; then
   echo "No game files found. Installing..."

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -111,8 +111,10 @@ function assert_free_disk_space() {
   fi
 
   # repair installs already have most content on disk and steamcmd validate
-  # only fetches what is missing - the full-size gate is for fresh installs
-  if [[ -d "${ARK_SERVER_VOLUME}/server/ShooterGame" ]]; then
+  # only fetches what is missing - the full-size gate is for fresh installs.
+  # Content is only ever created by the install path (not the config-symlink
+  # healing above), so it reliably marks a previous install attempt.
+  if [[ -d "${ARK_SERVER_VOLUME}/server/ShooterGame/Content" ]]; then
     return
   fi
 
@@ -175,12 +177,19 @@ CONFIG_DIR="./server/ShooterGame/Saved/Config/LinuxServer"
 for INI_FILE in Game.ini GameUserSettings.ini; do
   INI_LINK="${ARK_SERVER_VOLUME}/${INI_FILE}"
   if [[ -e "${INI_LINK}" ]] && [[ ! -L "${INI_LINK}" ]]; then
-    echo "${INI_LINK} is a regular file but should be a symlink to ${CONFIG_DIR}/${INI_FILE} - fixing..."
-    mkdir -p "${CONFIG_DIR}"
-    if [[ -f "${CONFIG_DIR}/${INI_FILE}" ]]; then
-      cp -a "${CONFIG_DIR}/${INI_FILE}" "${CONFIG_DIR}/${INI_FILE}.bak"
+    if [[ ! -f "${INI_LINK}" ]]; then
+      echo "${INI_LINK} exists but is not a file - moving it aside..."
+      mv "${INI_LINK}" "${INI_LINK}.invalid.$(date +%s)"
+    else
+      echo "${INI_LINK} is a regular file but should be a symlink to ${CONFIG_DIR}/${INI_FILE} - fixing..."
+      mkdir -p "${CONFIG_DIR}"
+      if [[ -d "${CONFIG_DIR}/${INI_FILE}" ]]; then
+        mv "${CONFIG_DIR}/${INI_FILE}" "${CONFIG_DIR}/${INI_FILE}.invalid.$(date +%s)"
+      elif [[ -f "${CONFIG_DIR}/${INI_FILE}" ]]; then
+        cp -a "${CONFIG_DIR}/${INI_FILE}" "${CONFIG_DIR}/${INI_FILE}.bak"
+      fi
+      mv -f "${INI_LINK}" "${CONFIG_DIR}/${INI_FILE}"
     fi
-    mv -f "${INI_LINK}" "${CONFIG_DIR}/${INI_FILE}"
   fi
   [[ -L "${INI_LINK}" ]] || ln -s "${CONFIG_DIR}/${INI_FILE}" "${INI_FILE}"
 done


### PR DESCRIPTION
## Problem

`/app/Game.ini` and `/app/GameUserSettings.ini` are convenience symlinks into `server/ShooterGame/Saved/Config/LinuxServer/`. Users regularly replace them with **regular files** by accident — SFTP uploads and many editors silently break symlinks. On the next start the entrypoint ran `ln -s` onto the existing file, failed with `File exists`, `set -e` killed the script and the container crash-looped with no useful message. That is exactly the failure in #133.

## Fix

The entrypoint now detects the situation and heals it:

1. If `Game.ini`/`GameUserSettings.ini` in the volume root is a regular file, its content is adopted as the real config file (the user uploaded it intending exactly that) — the previous real file is kept as `.bak`.
2. The symlink is re-created.

No behavior change for healthy volumes.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)