### PR TITLE
feat: add ARK_EXTRA_OPTS for arbitrary ARK command line options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV         IMAGE_VERSION="${IMAGE_VERSION}" \
             ADMIN_PASSWORD="Th155houldD3f1n3tlyB3Chang3d" \
             MAX_PLAYERS="20" \
             GAME_MOD_IDS="" \
+            ARK_EXTRA_OPTS="" \
             UPDATE_ON_START="false" \
             VALIDATE_ON_START="false" \
             BACKUP_ON_STOP="false" \

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Basic configuration is done with environment variables:
 | WARN_ON_STOP | true | Broadcast a shutdown warning to players when the container is stopped gracefully |
 | ENABLE_CROSSPLAY | false | Enable crossplay (starts the server with `-crossplay`). When enabled, BattlEye should be disabled as it likes to disconnect Epic players |
 | DISABLE_BATTLEYE | false | Disable BattlEye protection (starts the server with `-NoBattlEye`) |
+| ARK_EXTRA_OPTS | `empty` | Additional ARK command line options, space separated (e.g. `ARK_EXTRA_OPTS=-ForceAllowCaveFlyers -PreventHibernation`) |
 | BETA | `empty` | Opt into a Steam beta branch if necessary (e.g. `BETA=preaquatica`) |
 | BETA_ACCESSCODE | `empty` | Access code for the chosen beta branch, if it requires one |
 | STEAM_LOGIN | anonymous | Steam account used by `steamcmd` (see [Steam login session](#configure-a-steam-login-session)) |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Basic configuration is done with environment variables:
 | WARN_ON_STOP | true | Broadcast a shutdown warning to players when the container is stopped gracefully |
 | ENABLE_CROSSPLAY | false | Enable crossplay (starts the server with `-crossplay`). When enabled, BattlEye should be disabled as it likes to disconnect Epic players |
 | DISABLE_BATTLEYE | false | Disable BattlEye protection (starts the server with `-NoBattlEye`) |
-| ARK_EXTRA_OPTS | `empty` | Additional ARK command line options, space separated (e.g. `ARK_EXTRA_OPTS=-ForceAllowCaveFlyers -PreventHibernation`) |
+| ARK_EXTRA_OPTS | `empty` | Additional ARK command line options, space separated (e.g. `ARK_EXTRA_OPTS=-ForceAllowCaveFlyers -PreventHibernation`). Each option must be of the form `-Flag` or `-Name=Value`; spaces inside an option are not supported |
 | BETA | `empty` | Opt into a Steam beta branch if necessary (e.g. `BETA=preaquatica`) |
 | BETA_ACCESSCODE | `empty` | Access code for the chosen beta branch, if it requires one |
 | STEAM_LOGIN | anonymous | Steam account used by `steamcmd` (see [Steam login session](#configure-a-steam-login-session)) |

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -144,6 +144,11 @@ fi
 if [[ "${DISABLE_BATTLEYE}" == "true" ]]; then
   args=('--arkopt,-NoBattlEye' "${args[@]}")
 fi
+# pass arbitrary additional ARK command line options, space separated,
+# e.g. ARK_EXTRA_OPTS="-ForceAllowCaveFlyers -PreventHibernation"
+for EXTRA_OPT in ${ARK_EXTRA_OPTS}; do
+  args=("--arkopt,${EXTRA_OPT}" "${args[@]}")
+done
 BETA_ARGS=(${BETA:+--beta=${BETA}} ${BETA_ACCESSCODE:+--betapassword=${BETA_ACCESSCODE}})
 
 echo "_______________________________________"

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -146,9 +146,11 @@ if [[ "${DISABLE_BATTLEYE}" == "true" ]]; then
 fi
 # pass arbitrary additional ARK command line options, space separated,
 # e.g. ARK_EXTRA_OPTS="-ForceAllowCaveFlyers -PreventHibernation"
+EXTRA_ARGS=()
 for EXTRA_OPT in ${ARK_EXTRA_OPTS}; do
-  args=("--arkopt,${EXTRA_OPT}" "${args[@]}")
+  EXTRA_ARGS+=("--arkopt,${EXTRA_OPT}")
 done
+args=("${EXTRA_ARGS[@]}" "${args[@]}")
 BETA_ARGS=(${BETA:+--beta=${BETA}} ${BETA_ACCESSCODE:+--betapassword=${BETA_ACCESSCODE}})
 
 echo "_______________________________________"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - PRE_UPDATE_BACKUP=${PRE_UPDATE_BACKUP}
       - WARN_ON_STOP=${WARN_ON_STOP}
       - GAME_MOD_IDS=${GAME_MOD_IDS}
+      - ARK_EXTRA_OPTS=${ARK_EXTRA_OPTS}
     ports:
       # Port for connections from ARK game client
       - "7777:7777/udp"

--- a/deploy/example.env
+++ b/deploy/example.env
@@ -9,3 +9,5 @@ UPDATE_ON_START=true
 BACKUP_ON_STOP=false
 PRE_UPDATE_BACKUP=true
 WARN_ON_STOP=true
+# Additional ARK command line options, space separated (-Flag or -Name=Value)
+ARK_EXTRA_OPTS=


### PR DESCRIPTION
## Problem

Every additional launch flag so far required its own hardcoded env var (`ENABLE_CROSSPLAY`, `DISABLE_BATTLEYE`, …). Flags like `-ForceAllowCaveFlyers` were impossible without forking the image — which is exactly what the reporter of #102 ended up doing.

## Fix

New generic pass-through:

| Variable | Default | Effect |
|---|---|---|
| `ARK_EXTRA_OPTS` | `empty` | Space-separated raw ARK command line options, passed to the server via arkmanager's `--arkopt` mechanism |

Example:

```yaml
    environment:
      - ARK_EXTRA_OPTS=-ForceAllowCaveFlyers -PreventHibernation
```

This permanently ends the *'please add an env var for flag X'* class of feature requests — any current or future ARK flag works without image changes. `ENABLE_CROSSPLAY`/`DISABLE_BATTLEYE` keep working unchanged.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)