### PR TITLE
feat: support PUID/PGID to remap the steam user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ ENV         IMAGE_VERSION="${IMAGE_VERSION}" \
             SERVER_LIST_PORT="27015" \
             STEAM_HOME="/home/${USER}" \
             STEAM_USER="${USER}" \
-            STEAM_LOGIN="anonymous"
+            STEAM_LOGIN="anonymous" \
+            PUID="" \
+            PGID=""
 
 ENV         ARK_TOOLS_DIR="${ARK_SERVER_VOLUME}/arkmanager"
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Basic configuration is done with environment variables:
 | BETA_ACCESSCODE | `empty` | Access code for the chosen beta branch, if it requires one |
 | STEAM_LOGIN | anonymous | Steam account used by `steamcmd` (see [Steam login session](#configure-a-steam-login-session)) |
 | ARK_SERVER_VOLUME | /app | Path inside the container where the server files are stored |
+| PUID | `empty` | Run the server with a custom UID, e.g. to match the owner of a bind mount on NAS systems. The first start after a change re-chowns the volume once, which can take a while |
+| PGID | `empty` | Run the server with a custom GID (see `PUID`) |
 | GAME_CLIENT_PORT | 7777 | Exposed game client port |
 | UDP_SOCKET_PORT | 7778 | Raw UDP socket port (always game client port +1) |
 | RCON_PORT | 27020 | Exposed RCON port |

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Basic configuration is done with environment variables:
 | BETA_ACCESSCODE | `empty` | Access code for the chosen beta branch, if it requires one |
 | STEAM_LOGIN | anonymous | Steam account used by `steamcmd` (see [Steam login session](#configure-a-steam-login-session)) |
 | ARK_SERVER_VOLUME | /app | Path inside the container where the server files are stored |
-| PUID | `empty` | Run the server with a custom UID, e.g. to match the owner of a bind mount on NAS systems. The first start after a change re-chowns the volume once, which can take a while |
+| PUID | `empty` | Run the server with a custom UID, e.g. to match the owner of a bind mount on NAS systems. If the server volume's ownership does not match, it is adopted once via a recursive chown, which can take a while |
 | PGID | `empty` | Run the server with a custom GID (see `PUID`) |
 | GAME_CLIENT_PORT | 7777 | Exposed game client port |
 | UDP_SOCKET_PORT | 7778 | Raw UDP socket port (always game client port +1) |
@@ -269,7 +269,9 @@ created `Steam` directory into your ARK container:
       - ./Steam:/home/steam/Steam:rw
 ```
 
-`arkmanager` will then install/update ARK using your login.
+`arkmanager` will then install/update ARK using your login. When using
+`PUID`/`PGID`, the ARK container adopts ownership of the mounted Steam
+session automatically on start.
 
 ⚠️ **Upgrade note:** the arkmanager config in your volume is only created once
 and never overwritten. If your server volume was first created with an image

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -8,6 +8,30 @@ if [[ ! -d "${ARK_SERVER_VOLUME}" ]]; then
   mkdir -p "${ARK_SERVER_VOLUME}"
 fi
 
+# Optionally remap the steam user to a custom UID/GID, e.g. to match the
+# owner of a bind mount on NAS systems (Synology, UGREEN, ...)
+if [[ -n "${PUID}${PGID}" ]]; then
+  CURRENT_UID="$(id -u "${STEAM_USER}")"
+  CURRENT_GID="$(id -g "${STEAM_USER}")"
+  STEAM_GROUP="$(id -gn "${STEAM_USER}")"
+  TARGET_UID="${PUID:-${CURRENT_UID}}"
+  TARGET_GID="${PGID:-${CURRENT_GID}}"
+
+  if [[ "${TARGET_GID}" != "${CURRENT_GID}" ]]; then
+    echo "Changing GID of ${STEAM_USER} from ${CURRENT_GID} to ${TARGET_GID}..."
+    groupmod -o -g "${TARGET_GID}" "${STEAM_GROUP}"
+  fi
+  if [[ "${TARGET_UID}" != "${CURRENT_UID}" ]]; then
+    echo "Changing UID of ${STEAM_USER} from ${CURRENT_UID} to ${TARGET_UID}..."
+    usermod -o -u "${TARGET_UID}" "${STEAM_USER}"
+  fi
+  if [[ "${TARGET_UID}" != "${CURRENT_UID}" ]] || [[ "${TARGET_GID}" != "${CURRENT_GID}" ]]; then
+    echo "Adopting ownership of ${STEAM_HOME} and ${ARK_SERVER_VOLUME} (one-time, may take a while)..."
+    chown -R "${STEAM_USER}": "${STEAM_HOME}" || echo "Failed setting rights on ${STEAM_HOME}, continuing startup..."
+    chown -R "${STEAM_USER}": "${ARK_SERVER_VOLUME}" || echo "Failed setting rights on ${ARK_SERVER_VOLUME}, continuing startup..."
+  fi
+fi
+
 chown "${STEAM_USER}": "${ARK_SERVER_VOLUME}" || echo "Failed setting rights on ${ARK_SERVER_VOLUME}, continuing startup..."
 
 if [[ ! -d ${ARK_TOOLS_DIR} ]]; then

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -11,11 +11,23 @@ fi
 # Optionally remap the steam user to a custom UID/GID, e.g. to match the
 # owner of a bind mount on NAS systems (Synology, UGREEN, ...)
 if [[ -n "${PUID}${PGID}" ]]; then
+  for ID_VAR in PUID PGID; do
+    if [[ -n "${!ID_VAR}" ]] && [[ ! "${!ID_VAR}" =~ ^[0-9]+$ ]]; then
+      echo "ERROR: ${ID_VAR} must be numeric, got '${!ID_VAR}'"
+      exit 1
+    fi
+  done
+  if [[ "${PUID}" == "0" ]] || [[ "${PGID}" == "0" ]]; then
+    echo "ERROR: PUID/PGID 0 (root) is not supported"
+    exit 1
+  fi
+
   CURRENT_UID="$(id -u "${STEAM_USER}")"
   CURRENT_GID="$(id -g "${STEAM_USER}")"
   STEAM_GROUP="$(id -gn "${STEAM_USER}")"
-  TARGET_UID="${PUID:-${CURRENT_UID}}"
-  TARGET_GID="${PGID:-${CURRENT_GID}}"
+  # 10# forces base-10 so values like "01000" cannot be read as octal
+  TARGET_UID="$((10#${PUID:-${CURRENT_UID}}))"
+  TARGET_GID="$((10#${PGID:-${CURRENT_GID}}))"
 
   if [[ "${TARGET_GID}" != "${CURRENT_GID}" ]]; then
     echo "Changing GID of ${STEAM_USER} from ${CURRENT_GID} to ${TARGET_GID}..."
@@ -26,9 +38,17 @@ if [[ -n "${PUID}${PGID}" ]]; then
     usermod -o -u "${TARGET_UID}" "${STEAM_USER}"
   fi
   if [[ "${TARGET_UID}" != "${CURRENT_UID}" ]] || [[ "${TARGET_GID}" != "${CURRENT_GID}" ]]; then
-    echo "Adopting ownership of ${STEAM_HOME} and ${ARK_SERVER_VOLUME} (one-time, may take a while)..."
+    # small, container-local; also adopts a mounted /home/steam/Steam session
     chown -R "${STEAM_USER}": "${STEAM_HOME}" || echo "Failed setting rights on ${STEAM_HOME}, continuing startup..."
-    chown -R "${STEAM_USER}": "${ARK_SERVER_VOLUME}" || echo "Failed setting rights on ${ARK_SERVER_VOLUME}, continuing startup..."
+  fi
+
+  # adopt the server volume only when its ownership actually differs:
+  # containers are recreated on every image update and re-running a
+  # recursive chown over ~25GB each time would hurt exactly the NAS
+  # systems this feature is for
+  if [[ "$(stat -c '%u:%g' "${ARK_SERVER_VOLUME}")" != "${TARGET_UID}:${TARGET_GID}" ]]; then
+    echo "Adopting ownership of ${ARK_SERVER_VOLUME} (one-time, may take a while)..."
+    chown -R "${TARGET_UID}:${TARGET_GID}" "${ARK_SERVER_VOLUME}" || echo "Failed setting rights on ${ARK_SERVER_VOLUME}, continuing startup..."
   fi
 fi
 

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 [[ -z "${DEBUG}" ]] || [[ "${DEBUG,,}" = "false" ]] || [[ "${DEBUG,,}" = "0" ]] || set -x
 
-if [[ "$(whoami)" != "${STEAM_USER}" ]]; then
+if [[ "$(id -u)" != "$(id -u "${STEAM_USER}")" ]]; then
   echo "run this script as steam-user"
   exit 1
 fi

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       - PRE_UPDATE_BACKUP=${PRE_UPDATE_BACKUP}
       - WARN_ON_STOP=${WARN_ON_STOP}
       - GAME_MOD_IDS=${GAME_MOD_IDS}
+      - PUID=${PUID:-}
+      - PGID=${PGID:-}
       - ARK_EXTRA_OPTS=${ARK_EXTRA_OPTS}
     ports:
       # Port for connections from ARK game client

--- a/deploy/example.env
+++ b/deploy/example.env
@@ -9,5 +9,8 @@ UPDATE_ON_START=true
 BACKUP_ON_STOP=false
 PRE_UPDATE_BACKUP=true
 WARN_ON_STOP=true
+# Uncomment to run the server with a custom UID/GID (e.g. NAS bind mounts)
+#PUID=1000
+#PGID=1000
 # Additional ARK command line options, space separated (-Flag or -Name=Value)
 ARK_EXTRA_OPTS=


### PR DESCRIPTION
## Problem

The container always runs the server as UID/GID 1000. On NAS systems (Synology, UGREEN, …) bind mounts are typically owned by a different user (e.g. 1037:100 in #69), so the installation fails with `Permission denied` errors users cannot fix from the outside. PUID/PGID is the convention such users expect from the linuxserver.io ecosystem — #69 literally opens with *'Normally I set PUID/GUID to 1037/100 and everything works'*.

## Fix

| Variable | Default | Effect |
|---|---|---|
| `PUID` | `empty` | Remap the container's `steam` user to this UID before dropping privileges |
| `PGID` | `empty` | Same for the group |

- No-op when unset or when the IDs already match — zero change for existing setups.
- When the IDs actually change, the entrypoint adopts ownership of the steam home and the server volume **once** (logged, can take a while on a full 25GB install).
- Works together with the cron fix (#142): jobs run via `crontab -u steam` and are unaffected by the remap.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
