### PR TITLE
docs: add Troubleshooting section and steam-login.sh helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
-deploy/
+deploy/*
 !deploy/example.env
 !deploy/docker-compose.yml
+!deploy/steam-login.sh
 volumes/

--- a/README.md
+++ b/README.md
@@ -248,7 +248,14 @@ docker restart ark-server
 For `steamcmd` to respect your account's non-anonymous DLCs and content, mount
 a Steam session into the container.
 
-First, log in once with `steamcmd` to create a valid session:
+The [`deploy/steam-login.sh`](deploy/steam-login.sh) helper automates the
+whole procedure (including resetting a broken session):
+
+```bash
+cd deploy && STEAM_LOGIN=your_steam_username ./steam-login.sh
+```
+
+Or do it manually: log in once with `steamcmd` to create a valid session:
 
 ```shell
 mkdir Steam && chown 1000:1000 Steam
@@ -278,6 +285,97 @@ and never overwritten. If your server volume was first created with an image
 older than timestamp `1656497302`, edit line 15 of
 `<your-volume>/arkmanager/arkmanager.cfg` and replace it with:
 `steamlogin="${STEAM_LOGIN}"`
+
+## Troubleshooting
+
+### `[S_API FAIL] SteamAPI_Init() failed` in the logs
+
+Harmless. This message shows up on virtually every steamcmd-based dedicated
+server (there is no Steam client running inside the container) and is **not**
+the reason your server is unreachable.
+
+### Log lines full of backslashes (`TheIsland\?SessionName=My\ Server`)
+
+Also harmless — arkmanager logs the launch command in shell-escaped form.
+The server receives the unescaped values.
+
+### Server does not show up in the server list / cannot connect
+
+- ARK speaks **UDP**. All three UDP ports (`7777`, `7778`, `27015`) must be
+  published *and* forwarded in your router/firewall; `7778` must stay game
+  client port +1.
+- The in-game server browser is slow and unreliable. Test via the Steam
+  client instead: *View → Game Servers → Favorites → Add* `your-ip:27015`.
+- Give a freshly started server several minutes before it responds to
+  queries — map loading and mod installs take time.
+- Docker Desktop on macOS/Windows has flaky UDP port forwarding. On a Linux
+  host, `network_mode: host` (drop the `ports:` section) is the most reliable
+  setup if the lists stay empty.
+- Port-remapping tunnel services (playit.gg and friends) break ARK's
+  assumption that the raw socket port is game port +1 and that the query port
+  it announces is reachable — prefer plain port forwarding.
+
+### Changes to `Game.ini` / `GameUserSettings.ini` disappear
+
+The ARK **server itself** rewrites both files on startup and shutdown — that
+is game behavior, not this image. Stop the container first, then edit, then
+start:
+
+```bash
+docker stop -t 300 ark-server
+vim "${HOME}/ark-server/GameUserSettings.ini"
+docker start ark-server
+```
+
+Also note that settings supplied on the command line (via the environment
+variables / arkmanager) override the corresponding INI values.
+
+### How much RAM / disk do I need?
+
+Plan with **at least 8 GB of RAM** (more with mods and larger maps — ARK is
+hungry) and **~25 GB of disk** for the base install, plus headroom for
+staging, backups and mods. Memory can be capped with docker's usual
+`mem_limit` / `deploy.resources` settings, but if the limit is below what the
+map needs the server will simply be OOM-killed.
+
+### Restore a backup
+
+`arkmanager restore` must not run while the server is up — the next autosave
+would overwrite the restored files again. Use a throwaway container on the
+stopped volume:
+
+```bash
+# 1. stop the server gracefully (world save)
+docker stop -t 300 ark-server
+
+# 2. restore (picks the most recent backup; pass a backup file to choose one)
+docker run --rm -it -v "${HOME}/ark-server:/app" --entrypoint bash hermsi/ark-server \
+  -c 'rm -rf /etc/arkmanager && ln -s /app/arkmanager /etc/arkmanager && gosu steam arkmanager restore'
+
+# 3. start the server again
+docker start ark-server
+```
+
+### Xbox crossplay?
+
+Not possible with this image. ASE's `-crossplay` flag covers **Steam and
+Epic** players only; console crossplay requires the Windows-Store/"Play
+Anywhere" server or ARK: Survival Ascended — both out of scope here.
+
+### arm64 / Raspberry Pi / Apple Silicon?
+
+Not possible — see [Architecture](#architecture): the ARK server binary only
+exists for x86-64.
+
+### Mods fail to download / `No cached credentials`
+
+Non-anonymous content requires a persistent
+[Steam login session](#configure-a-steam-login-session). If an interactive
+login dies with `Assertion Failed: Failed to write file after download`,
+delete the mounted `Steam` session directory and log in again (a known
+steamcmd quirk — accounts using the Steam Guard **mobile authenticator**
+work most reliably); the bundled
+[`deploy/steam-login.sh`](deploy/steam-login.sh) automates exactly that.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -356,6 +356,9 @@ docker run --rm -it -v "${HOME}/ark-server:/app" --entrypoint bash hermsi/ark-se
 docker start ark-server
 ```
 
+If you run with `PUID`/`PGID`, replace `gosu steam` with `gosu <PUID>:<PGID>`
+(gosu accepts numeric ids) so the restored files get the right owner.
+
 ### Xbox crossplay?
 
 Not possible with this image. ASE's `-crossplay` flag covers **Steam and

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     #  context: ../.
     volumes:
       # # This setup is necessary if you have to download a non-anonymous appID/modID
-      # ${STEAM_SESSION_VOLUME}:/home/steam/Steam
+      #- ${STEAM_SESSION_VOLUME}:/home/steam/Steam
       - ${ARK_SERVER_VOLUME}:/app
     environment:
       # # This setup is necessary if you have to download a non-anonymous appID/modID

--- a/deploy/example.env
+++ b/deploy/example.env
@@ -1,5 +1,9 @@
 COMPOSE_PROJECT_NAME=ark
 ARK_SERVER_VOLUME=ark-data
+# Uncomment for non-anonymous downloads, see README "Configure a Steam login session"
+# (create the session with ./steam-login.sh first)
+#STEAM_LOGIN=your_steam_username
+#STEAM_SESSION_VOLUME=./Steam
 SESSION_NAME=Dockerized ARK Server by github.com/hermsi1337
 SERVER_MAP=TheIsland
 SERVER_PASSWORD=YouShallNotPass

--- a/deploy/steam-login.sh
+++ b/deploy/steam-login.sh
@@ -15,9 +15,11 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
+# .env is a compose dotenv file, not valid bash (values are unquoted) -
+# extract only the keys we need, command line values take precedence
 if [[ -f ".env" ]]; then
-  # shellcheck disable=SC1091
-  source ".env"
+  STEAM_LOGIN="${STEAM_LOGIN:-$(sed -n 's/^STEAM_LOGIN=//p' .env | tail -n1)}"
+  STEAM_SESSION_VOLUME="${STEAM_SESSION_VOLUME:-$(sed -n 's/^STEAM_SESSION_VOLUME=//p' .env | tail -n1)}"
 fi
 
 STEAM_SESSION_VOLUME="${STEAM_SESSION_VOLUME:-${PWD}/Steam}"

--- a/deploy/steam-login.sh
+++ b/deploy/steam-login.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Create or refresh the persistent Steam session used with STEAM_LOGIN.
+# See the README section "Configure a Steam login session".
+#
+# Usage:
+#   STEAM_LOGIN=your_steam_username ./steam-login.sh
+# or set STEAM_LOGIN (and optionally STEAM_SESSION_VOLUME) in ./.env
+#
+# steamcmd will prompt for your password and Steam Guard interactively.
+# If a previous session is broken (e.g. 'Assertion Failed: Failed to write
+# file after download'), pass --reset to wipe it before logging in again.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if [[ -f ".env" ]]; then
+  # shellcheck disable=SC1091
+  source ".env"
+fi
+
+STEAM_SESSION_VOLUME="${STEAM_SESSION_VOLUME:-${PWD}/Steam}"
+IMAGE="${IMAGE:-hermsi/ark-server:latest}"
+
+if [[ -z "${STEAM_LOGIN:-}" ]] || [[ "${STEAM_LOGIN}" == "anonymous" ]]; then
+  echo "ERROR: set STEAM_LOGIN to your Steam username, e.g.:"
+  echo "       STEAM_LOGIN=your_steam_username ${0}"
+  exit 1
+fi
+
+if [[ "${1:-}" == "--reset" ]]; then
+  echo "Wiping existing Steam session in ${STEAM_SESSION_VOLUME}..."
+  rm -rf "${STEAM_SESSION_VOLUME}"
+fi
+
+mkdir -p "${STEAM_SESSION_VOLUME}"
+
+# the session files must belong to the container's steam user
+docker run --rm -v "${STEAM_SESSION_VOLUME}:/home/steam/Steam" \
+  --entrypoint chown "${IMAGE}" -R steam: /home/steam/Steam
+
+docker run --rm -it -u steam \
+  -v "${STEAM_SESSION_VOLUME}:/home/steam/Steam" \
+  --entrypoint /home/steam/steamcmd/steamcmd.sh \
+  "${IMAGE}" +login "${STEAM_LOGIN}" +quit
+
+echo ""
+echo "Steam session stored in ${STEAM_SESSION_VOLUME}."
+echo "Mount it into your server container as /home/steam/Steam and set STEAM_LOGIN=${STEAM_LOGIN}."


### PR DESCRIPTION
## What

A README **Troubleshooting** section answering the questions that make up the bulk of this issue tracker, plus a `deploy/steam-login.sh` helper that automates creating/refreshing the persistent Steam session.

## Covered topics → closed issues

| Topic | Issues |
|---|---|
| `[S_API FAIL] SteamAPI_Init() failed` is harmless | #93, #108 |
| Escaped launch-command log lines are harmless | #101 |
| Server not visible / cannot connect (UDP ports, unreliable in-game browser, Docker Desktop UDP quirks, `network_mode: host` tip, port-remapping tunnels like playit.gg) | #89, #93, #98, #106 |
| `Game.ini` / `GameUserSettings.ini` rewritten by the **game itself** — stop container first, then edit; CLI options override INI | #135, #101 |
| RAM / disk requirements (≥8 GB RAM, ~25 GB disk) | #85 |
| Restore runbook — `arkmanager restore` must not run against a live server, else the next autosave overwrites it | #138 |
| Xbox crossplay impossible with ASE (`-crossplay` = Steam+Epic only) | #100 |
| arm64 impossible (x86-64-only server binary) | #96 |
| Broken Steam sessions / `No cached credentials` mod failures | #91, #130 |

## steam-login.sh

Interactive helper for the "Configure a Steam login session" flow: creates the session volume with correct ownership, lets steamcmd prompt for password/Steam Guard itself (no password in argv or shell history), and offers `--reset` to wipe a broken session — the fix for the `Assertion Failed: Failed to write file after download` loop from #130.

Also fixes `.gitignore`: `deploy/` ignored the whole directory, so the negated entries below it never worked (git does not descend into ignored directories); `deploy/*` restores the intended behavior.

Closes #85
Closes #89
Closes #91
Closes #93
Closes #96
Closes #98
Closes #100
Closes #101
Closes #106
Closes #108
Closes #130
Closes #135
Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
