### PR TITLE
ci: auto-update the arkmanager pin via weekly bump PRs

### DIFF
--- a/.github/workflows/update-arkmanager-pin.yml
+++ b/.github/workflows/update-arkmanager-pin.yml
@@ -59,11 +59,15 @@ jobs:
           NEW_TAG: ${{ steps.latest.outputs.tag }}
         run: |
           sed -i -E "s/^(ARG +ARK_TOOLS_VERSION=\")[^\"]+(\")/\1${NEW_TAG}\2/" Dockerfile
+          grep -qF "ARK_TOOLS_VERSION=\"${NEW_TAG}\"" Dockerfile || {
+            echo "::error::sed did not update the Dockerfile pin - has the ARG line format changed?"
+            exit 1
+          }
           grep -n 'ARK_TOOLS_VERSION' Dockerfile
 
       - name: Open pull request
         if: steps.latest.outputs.tag != steps.current.outputs.tag
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: bot/update-arkmanager-pin
           delete-branch: true

--- a/.github/workflows/update-arkmanager-pin.yml
+++ b/.github/workflows/update-arkmanager-pin.yml
@@ -1,0 +1,85 @@
+name: Update arkmanager pin
+
+# Dependabot cannot track the ARK_TOOLS_VERSION build ARG (its docker
+# ecosystem only understands FROM lines), so this workflow does the
+# equivalent: check the latest ark-server-tools release once a week and
+# open a bump PR when the Dockerfile default is behind.
+#
+# The pin only affects local/manual builds - published images are always
+# built against the current ark-server-tools master commit resolved at
+# build time (see build-and-deploy.yml).
+
+on:
+  schedule:
+    - cron: '0 1 * * 1'  # every monday at 01:00 UTC, before the weekly image build
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-arkmanager-pin
+  cancel-in-progress: true
+
+jobs:
+  update-pin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Resolve latest ark-server-tools release
+        id: latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="$(gh api repos/arkmanager/ark-server-tools/releases/latest --jq .tag_name)"
+          # the Dockerfile picks netinstall's --tag vs --commit based on the
+          # leading 'v'; this also guards the sed below against odd tag names
+          if [[ ! "${TAG}" =~ ^v[0-9][A-Za-z0-9._-]*$ ]]; then
+            echo "Unexpected release tag format: '${TAG}'" >&2
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Read current pin
+        id: current
+        run: |
+          TAG="$(sed -nE 's/^ARG +ARK_TOOLS_VERSION="([^"]+)".*/\1/p' Dockerfile)"
+          if [[ -z "${TAG}" ]]; then
+            echo "Could not find the ARK_TOOLS_VERSION ARG in the Dockerfile" >&2
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Update Dockerfile
+        if: steps.latest.outputs.tag != steps.current.outputs.tag
+        env:
+          NEW_TAG: ${{ steps.latest.outputs.tag }}
+        run: |
+          sed -i -E "s/^(ARG +ARK_TOOLS_VERSION=\")[^\"]+(\")/\1${NEW_TAG}\2/" Dockerfile
+          grep -n 'ARK_TOOLS_VERSION' Dockerfile
+
+      - name: Open pull request
+        if: steps.latest.outputs.tag != steps.current.outputs.tag
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: bot/update-arkmanager-pin
+          delete-branch: true
+          commit-message: "chore: bump arkmanager pin to ${{ steps.latest.outputs.tag }}"
+          title: "chore: bump arkmanager pin to ${{ steps.latest.outputs.tag }}"
+          body: |
+            Bumps the `ARK_TOOLS_VERSION` default in the `Dockerfile` from
+            `${{ steps.current.outputs.tag }}` to `${{ steps.latest.outputs.tag }}`.
+
+            Release notes: https://github.com/arkmanager/ark-server-tools/releases/tag/${{ steps.latest.outputs.tag }}
+
+            The pin only affects **local/manual builds** — published images are
+            always built against the current ark-server-tools `master` commit
+            resolved at build time, so this is a hygiene bump for reproducible
+            local builds.
+
+            > Note: PRs opened by a workflow with the default `GITHUB_TOKEN` do
+            > not trigger the preview build. Close and reopen this PR if you
+            > want the smoke build to run before merging.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ downstream compose files and scripts.
 | `deploy/` | Example `docker-compose.yml` + `example.env` for end users |
 | `.github/workflows/build-and-deploy.yml` | "Build and Publish" — builds and pushes to all three registries |
 | `.github/workflows/deploy-preview.yml` | "Build PR Preview" — builds PRs, pushes `pr-<n>` for same-repo PRs |
+| `.github/workflows/update-arkmanager-pin.yml` | "Update arkmanager pin" — weekly bump PR for the `ARK_TOOLS_VERSION` default |
 | `.github/dependabot.yml` | Weekly `github-actions` version updates |
 
 ## CI/CD
@@ -61,6 +62,16 @@ downstream compose files and scripts.
   secrets and never push. Same-repo PRs push `pr-<n>`, and only if the
   registry secrets are actually configured (the eligibility step checks for
   `DOCKERHUB_TOKEN`). Keep this property when editing the workflow.
+
+**Update arkmanager pin** (`update-arkmanager-pin.yml`):
+
+- Triggers: weekly cron **Mondays 01:00 UTC** and manual `workflow_dispatch`.
+- Dependabot cannot track a build ARG, so this workflow checks the latest
+  ark-server-tools release and opens a bump PR for the Dockerfile default.
+- Uses only the built-in `GITHUB_TOKEN` — which means the bump PR does **not**
+  trigger the preview build automatically (GitHub suppresses workflow-created
+  events); close/reopen the PR to run it, or rely on the master build after
+  merge. The actions it uses are themselves covered by Dependabot.
 
 **Required repository secrets:**
 
@@ -86,14 +97,17 @@ downstream compose files and scripts.
 
 ## Common tasks
 
-- **Bump the arkmanager pin:** check
+- **Bump the arkmanager pin:** automated — the "Update arkmanager pin"
+  workflow opens a weekly PR when a new ark-server-tools release exists;
+  review and merge it. Manual fallback: check
   `gh api repos/arkmanager/ark-server-tools/releases/latest --jq .tag_name`,
   update the `ARK_TOOLS_VERSION` ARG default in `Dockerfile`, PR it.
 - **Action version updates:** Dependabot opens weekly PRs; review the
   changelog, merge. The PR preview build doubles as the smoke test.
 - **Scheduled workflow got disabled?** GitHub disables cron workflows after
-  ~60 days without repository activity. Re-enable with
-  `gh workflow enable "Build and Publish"` (or via the Actions tab), then
+  ~60 days without repository activity — this affects both "Build and Publish"
+  and "Update arkmanager pin". Re-enable with
+  `gh workflow enable "<name>"` (or via the Actions tab), then
   `gh workflow run "Build and Publish"` for an immediate build.
 - **Manual release:** `gh workflow run "Build and Publish"` on `master`.
 


### PR DESCRIPTION
## Why

The `ARK_TOOLS_VERSION` default pin in the Dockerfile (currently `v1.6.69`) has to be bumped by hand — AGENTS.md even documents it as a manual task. **Dependabot cannot do this**: its docker ecosystem only understands `FROM` lines, and there is no ecosystem for 'a build ARG pointing at another repo's GitHub releases'.

## What

A small scheduled workflow that behaves exactly like Dependabot would:

- **Mondays 01:00 UTC** (one hour before the weekly image build) + `workflow_dispatch`
- Resolves the latest ark-server-tools release tag, validates the format (`^v[0-9][A-Za-z0-9._-]*$` — guards the sed and matches the Dockerfile's `--tag` vs `--commit` logic)
- If the Dockerfile default is behind: updates the ARG and opens/updates a bump PR (`bot/update-arkmanager-pin`) via `peter-evans/create-pull-request`
- No new secrets: runs on the built-in `GITHUB_TOKEN`

Sed extraction/replacement and the validation regex are tested against the real Dockerfile (ENV/netinstall references stay untouched — only the ARG line changes).

## Known limitation (documented in AGENTS.md + the bump-PR body)

PRs created with the default `GITHUB_TOKEN` do not trigger `pull_request` workflows, so the preview build won't run automatically on bump PRs — close/reopen the PR to run it, or rely on the post-merge master build. Avoiding that would require a PAT, which doesn't seem worth it for a docs-grade pin.

The workflow's own actions (`actions/checkout`, `peter-evans/create-pull-request`) are covered by the existing Dependabot `github-actions` configuration, so the bot maintains its own updater. AGENTS.md is updated accordingly (CI/CD section, layout table, common tasks, cron-disable note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)