### PR TITLE
fix(ci): resolve ark-server-tools commit authenticated and validated

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -35,8 +35,16 @@ jobs:
 
       - name: Determine ARK server tools version
         id: ark_tools
+        env:
+          # authenticated: unauthenticated calls share the runner IP's tiny
+          # rate limit and silently returned nothing under pressure
+          GH_TOKEN: ${{ github.token }}
         run: |
-          ARK_TOOLS_VERSION="$(curl -fsSL 'https://api.github.com/repos/arkmanager/ark-server-tools/commits' | jq -r '.[0].sha')"
+          ARK_TOOLS_VERSION="$(gh api repos/arkmanager/ark-server-tools/commits --jq '.[0].sha')"
+          if [[ ! "${ARK_TOOLS_VERSION}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::could not resolve the ark-server-tools master commit (got '${ARK_TOOLS_VERSION}')"
+            exit 1
+          fi
           echo "version=${ARK_TOOLS_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Set build timestamp

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -31,8 +31,16 @@ jobs:
 
       - name: Determine ARK server tools version
         id: ark_tools
+        env:
+          # authenticated: unauthenticated calls share the runner IP's tiny
+          # rate limit and silently returned nothing under pressure
+          GH_TOKEN: ${{ github.token }}
         run: |
-          ARK_TOOLS_VERSION="$(curl -fsSL 'https://api.github.com/repos/arkmanager/ark-server-tools/commits' | jq -r '.[0].sha')"
+          ARK_TOOLS_VERSION="$(gh api repos/arkmanager/ark-server-tools/commits --jq '.[0].sha')"
+          if [[ ! "${ARK_TOOLS_VERSION}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::could not resolve the ark-server-tools master commit (got '${ARK_TOOLS_VERSION}')"
+            exit 1
+          fi
           echo "version=${ARK_TOOLS_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Check shell script syntax


### PR DESCRIPTION
## What broke

[Run 29723571714](https://github.com/Hermsi1337/docker-ark-server/actions/runs/29723571714) (master publish after #149) failed inside `netinstall.sh` with *'Unable to get latest release'*. Root cause visible in the metadata log: `type=raw,value=tools-` — **the resolved commit was empty**.

The `Determine ARK server tools version` step calls `api.github.com` **unauthenticated**; GitHub-hosted runners share IPs and their tiny per-IP rate limit was exhausted. `curl -f` failed, but since the pipeline ends in `jq`, the step exited 0 with empty output. The empty build-arg then made `netinstall.sh` fall back to its own (also rate-limited) 'latest release' lookup and die. On a luckier day this would instead have **published a broken `tools-` tag**.

## Fix

- Resolve the commit via `gh api` with `GH_TOKEN: ${{ github.token }}` — per-token quota instead of per-IP, effectively immune to runner-IP rate limits (same pattern as the pin-update workflow from #149)
- Fail the step hard unless the result matches `^[0-9a-f]{40}$` — an empty/garbage version can never again reach the build or the `tools-` tag

Applied to both `build-and-deploy.yml` and `deploy-preview.yml` (same latent bug). This PR's own preview build exercises the fixed step live.

After merge I'll re-run **Build and Publish** to make up for the failed publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)