### PR TITLE
Add a container healthcheck

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ downstream compose files and scripts.
 | `Dockerfile` | Image build; installs arkmanager via upstream `netinstall.sh` |
 | `bin/docker-entrypoint.sh` | Container entrypoint (root: setup, cron, drops to steam user) |
 | `bin/steam-entrypoint.sh` | Server bootstrap/run as the `steam` user |
+| `bin/healthcheck.sh` | Container `HEALTHCHECK` (root: drops to the steam user, checks every managed instance) |
 | `conf.d/` | Templates copied into the image (`arkmanager.cfg`, `arkmanager-user.cfg`, `crontab`) |
 | `deploy/` | Example `docker-compose.yml` + `example.env` for end users |
 | `tests/` | bats suite for the pure-bash parts of `bin/steam-entrypoint.sh` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,12 @@ downstream compose files and scripts.
   instead of `unhealthy`. Reporting healthy there would unblock
   `depends_on: condition: service_healthy` and Swarm rollouts before the server
   exists. It is also judged per container, not per instance: one dead map must
-  not restart the container serving the other two.
+  not restart the container serving the other two. And a probe that gives up on
+  a hung `arkmanager status` has to leave nothing running: it goes off every
+  minute for the life of the container, so one surviving child per instance and
+  probe piles up into hundreds an hour. That is why the call runs as its own
+  process group and the group is signalled, instead of `timeout` alone, which
+  signals the command but not reliably what the command forked.
 - Keep entrypoint/runtime behavior and documented environment variables
   backward compatible; users run long-lived servers against `latest`.
 - **`bin/steam-entrypoint.sh` is sourceable.** Everything above the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,14 @@ downstream compose files and scripts.
   `RUN`.** The `RUN` pipes `netinstall.sh` into `bash`. Without `pipefail` a
   failed download exits 0, the build happily continues and the image ships
   without arkmanager.
+- **The healthcheck fails while the container bootstraps.** `bin/healthcheck.sh`
+  must never report healthy when it cannot tell what is running (no
+  `/app/running-instances`, empty or truncated file). A fresh container
+  downloads ~25GB, and `--start-period=6h` is what keeps that in `starting`
+  instead of `unhealthy`. Reporting healthy there would unblock
+  `depends_on: condition: service_healthy` and Swarm rollouts before the server
+  exists. It is also judged per container, not per instance: one dead map must
+  not restart the container serving the other two.
 - Keep entrypoint/runtime behavior and documented environment variables
   backward compatible; users run long-lived servers against `latest`.
 - **`bin/steam-entrypoint.sh` is sourceable.** Everything above the
@@ -153,9 +161,9 @@ downstream compose files and scripts.
   healing, the declarative INI files, mod id collection, install detection,
   the directory setup, the cluster config guard, the Discord config migration
   and its hardcoded webhook warning, the disk space check, the appended
-  arkmanager.cfg blocks and the backup budget and crash restart validation).
-  It never installs a server, arkmanager and steamcmd are stubbed in
-  `tests/stubs`.
+  arkmanager.cfg blocks, the backup budget and crash restart validation, the
+  `running-instances` state file the healthcheck reads). It never installs a
+  server, arkmanager and steamcmd are stubbed in `tests/stubs`.
 - **Writing tests:** assert with `[ ... ]` or the helpers in
   `tests/helper.bash`, never with `[[ ... ]]`. macOS ships bash 3.2, where a
   failing non-final `[[ ... ]]` does not fail the test, so those assertions

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,5 +88,8 @@ EXPOSE      ${GAME_CLIENT_PORT}/udp ${UDP_SOCKET_PORT}/udp ${SERVER_LIST_PORT}/u
 VOLUME      ["${ARK_SERVER_VOLUME}"]
 WORKDIR     ${ARK_SERVER_VOLUME}
 
+HEALTHCHECK --interval=1m --timeout=30s --start-period=5m --retries=5 \
+            CMD ["/healthcheck.sh"]
+
 ENTRYPOINT  ["/docker-entrypoint.sh"]
 CMD         []

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ ENV         IMAGE_VERSION="${IMAGE_VERSION}" \
             ALWAYS_RESTART_ON_CRASH="" \
             SKIP_DISK_CHECK="false" \
             DISCORD_WEBHOOK_URL="" \
+            DISABLE_HEALTHCHECK="false" \
+            HEALTHCHECK_REQUIRE_ALL_INSTANCES="false" \
+            HEALTHCHECK_UPDATE_GRACE_MINUTES="30" \
             CLUSTER_ID="" \
             SUB_INSTANCE_KEYS="" \
             ARK_TOOLS_VERSION="${ARK_TOOLS_VERSION}" \
@@ -88,7 +91,7 @@ EXPOSE      ${GAME_CLIENT_PORT}/udp ${UDP_SOCKET_PORT}/udp ${SERVER_LIST_PORT}/u
 VOLUME      ["${ARK_SERVER_VOLUME}"]
 WORKDIR     ${ARK_SERVER_VOLUME}
 
-HEALTHCHECK --interval=1m --timeout=30s --start-period=5m --retries=5 \
+HEALTHCHECK --interval=1m --timeout=45s --start-period=6h --retries=5 \
             CMD ["/healthcheck.sh"]
 
 ENTRYPOINT  ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -328,11 +328,18 @@ until morning.
 the two healthy maps keep it healthy and the dead one only shows up in the health
 log. Restarting the container would cut off the maps that are fine, and an
 instance that died while loading (bad map mod, for example) never comes back on
-its own, so it would restart forever. Set
+its own unless you set `ALWAYS_RESTART_ON_CRASH`, so it would restart forever. Set
 `HEALTHCHECK_REQUIRE_ALL_INSTANCES=true` if you would rather have the container
 go unhealthy as soon as one instance is missing. Note that this also applies to
 instances you stop by hand: with the default, `arkmanager stop @sub.Fjordur`
 keeps the container healthy, in strict mode it turns unhealthy.
+
+**`ALWAYS_RESTART_ON_CRASH` makes healthy mean less.** With it on, arkmanager
+relaunches a crashed instance in place every five seconds, so a crash looping
+server almost always has a live process and the container keeps reporting
+healthy. That is the container doing what you asked for, but the health status
+is then not the thing that will tell you something is wrong, watch the logs.
+See [Crash restarts](#crash-restarts).
 
 **No port probing.** arkmanager's run loop already watches the game port and
 restarts an instance that stopped listening for 60 seconds. Failing the health

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Basic configuration is done with environment variables:
 | SERVER_LIST_PORT | 27015 | Exposed server-list (query) port |
 | SKIP_DISK_CHECK | false | Skip the free-disk-space check (~25GB) before the initial server installation |
 | DISCORD_WEBHOOK_URL | `empty` | Discord webhook to notify on start, stop, crash and restart, see [Discord notifications](#discord-notifications) |
+| DISABLE_HEALTHCHECK | false | Set to `true` to make the [health check](#health-check) always report healthy, for UIs that do not expose `--no-healthcheck` |
+| HEALTHCHECK_REQUIRE_ALL_INSTANCES | false | Report unhealthy as soon as one instance is down, instead of only when all of them are, see [health check](#health-check) |
+| HEALTHCHECK_UPDATE_GRACE_MINUTES | 30 | How long stopped instances are excused while arkmanager holds its update lock |
 | CLUSTER_ID | `empty` | Setting a cluster id enables cluster mode (item/character transfer) and requires a volume mounted at `/cluster`, see [Cluster and multi-map support](#cluster-and-multi-map-support) |
 | SUB_INSTANCE_KEYS | `empty` | Additional map instances to run in this container, see [Cluster and multi-map support](#cluster-and-multi-map-support) |
 | DEBUG | `empty` | Set to `true` for verbose (`set -x`) entrypoint logging |
@@ -255,22 +258,30 @@ accepted and do nothing.
 
 ### Health check
 
-The image ships a `HEALTHCHECK`, so `docker ps` reports `healthy` / `unhealthy`
-and Kubernetes or Swarm have something to build a probe on. It asks
-`arkmanager status` about every instance this container manages (`main` plus one
-`sub.<KEY>` per entry in `SUB_INSTANCE_KEYS`) and fails as soon as one of them
-has no running server process.
+The image ships a `HEALTHCHECK`, so `docker ps` reports `starting`, `healthy` or
+`unhealthy` and compose can gate other services on it with
+`depends_on: condition: service_healthy`. It asks `arkmanager status` about every
+instance this container manages (`main` plus one `sub.<KEY>` per entry in
+`SUB_INSTANCE_KEYS`):
+
+* **healthy** as soon as at least one instance has a running server process
+* **unhealthy** when none of them has
+* **failing** (so `starting`, see below) while the container is still installing,
+  updating or has not launched the servers yet
+
+Healthy means the server processes are up, not that players can already join. An
+instance that is loading a map has a process but no open port for a few minutes.
 
 Defaults baked into the image:
 
 | Option | Default | Meaning |
 |---|---|---|
 | `--interval` | `1m` | Time between two checks |
-| `--timeout` | `30s` | A check that takes longer counts as failed |
-| `--start-period` | `5m` | Failures during this window after container start are not counted |
+| `--timeout` | `45s` | A check that takes longer counts as failed. Each instance is asked with a 10s timeout of its own, so raise this if you run more than four maps in one container |
+| `--start-period` | `6h` | Failures in this window keep the container `starting` instead of turning it `unhealthy` |
 | `--retries` | `5` | Consecutive failures before the container is marked `unhealthy` |
 
-So an instance has to be gone for about five minutes before the container turns
+So the servers have to be gone for about five minutes before the container turns
 unhealthy. That is on purpose: arkmanager restarts a crashed server on its own,
 and a restart plus map load can easily take a minute or two.
 
@@ -280,31 +291,69 @@ Override the timings per container (compose):
 services:
   server:
     healthcheck:
-      interval: 5m
-      timeout: 30s
-      start_period: 10m
-      retries: 3
+      interval: 1m
+      timeout: 45s
+      start_period: 6h
+      retries: 5
 ```
 
-With plain `docker run` use `--health-interval=5m --health-timeout=30s
---health-start-period=10m --health-retries=3`. To switch the check off entirely,
-use `healthcheck: disable: true` in compose or `--no-healthcheck` with
-`docker run`.
+With plain `docker run` use `--health-interval=1m --health-timeout=45s
+--health-start-period=6h --health-retries=5`. To switch the check off, set
+`DISABLE_HEALTHCHECK=true` (works everywhere, including NAS and Portainer UIs
+that do not expose the docker flags), or use `healthcheck: disable: true` in
+compose or `--no-healthcheck` with `docker run`.
 
-The first start is not covered by `--start-period` but by the check itself: the
-initial download is roughly 25GB, which is 20 minutes on a fast line and half a
-day on a slow one, so no fixed start period fits everyone. Instead the entrypoint
-writes `/app/running-instances` right before it launches the servers, and the
-check only demands a running process for the instances listed in that file.
-While the file is missing (install, mod downloads, `UPDATE_ON_START`) the
-container counts as healthy, and the same goes for the window in which arkmanager
-holds its update lock, e.g. during a cron update that stops the server for a
-while.
+**Why the start period is six hours.** The first start installs roughly 25GB,
+which is 20 minutes on a fast line and half a day on a slow one. The check fails
+during that time, on purpose, so nothing treats a downloading container as ready.
+Docker keeps it in `starting` for the whole start period, and those failures do
+not count towards `--retries`. The first success ends the start period early, so
+from the moment the servers are up a real outage still shows up after the usual
+five minutes. If your line needs longer than six hours, raise `start_period`.
 
-The check does not probe the game port. arkmanager's run loop already watches
-that and restarts an instance that stopped listening for 60 seconds, so failing
-the health check on it would report unhealthy exactly while the recovery is
+**Cron updates.** While arkmanager holds its update lock, stopped instances are
+excused for at most `HEALTHCHECK_UPDATE_GRACE_MINUTES` (default 30, counted from
+the moment the check actually starts excusing something, not from the start of
+the warning countdown). After that the container reports unhealthy even with the
+lock held, so a server that dies during the nightly update window is not hidden
+until morning.
+
+**One map down out of three.** By default the container is judged as a whole, so
+the two healthy maps keep it healthy and the dead one only shows up in the health
+log. Restarting the container would cut off the maps that are fine, and an
+instance that died while loading (bad map mod, for example) never comes back on
+its own, so it would restart forever. Set
+`HEALTHCHECK_REQUIRE_ALL_INSTANCES=true` if you would rather have the container
+go unhealthy as soon as one instance is missing. Note that this also applies to
+instances you stop by hand: with the default, `arkmanager stop @sub.Fjordur`
+keeps the container healthy, in strict mode it turns unhealthy.
+
+**No port probing.** arkmanager's run loop already watches the game port and
+restarts an instance that stopped listening for 60 seconds. Failing the health
+check on the same signal would report unhealthy exactly while that recovery is
 running.
+
+#### Kubernetes
+
+Kubernetes ignores the image `HEALTHCHECK` completely, you have to write the
+probes yourself. The script is the same:
+
+```yaml
+        startupProbe:
+          exec:
+            command: ["/healthcheck.sh"]
+          periodSeconds: 60
+          failureThreshold: 360   # 6 hours for the initial download
+        livenessProbe:
+          exec:
+            command: ["/healthcheck.sh"]
+          periodSeconds: 60
+          failureThreshold: 5
+          timeoutSeconds: 45
+```
+
+The startup probe is what replaces `--start-period`. Without it the liveness
+probe kills the pod long before the download is done.
 
 ### Data layout
 
@@ -319,7 +368,8 @@ Everything the server needs lives in the volume mounted at `/app`
 | `/app/staging` | Staging directory arkmanager downloads updates into, see [staged updates](#staged-updates) |
 | `/app/crontab` | Cron definitions loaded at container start |
 | `/app/environment` | Auto-generated on every start: container environment for cron jobs (contains credentials, mode 600) |
-| `/app/running-instances` | Auto-generated: the instances the [health check](#health-check) watches. Missing while the container is still installing or updating |
+| `/app/running-instances` | Auto-generated: the instances the [health check](#health-check) watches. Written when the servers are launched, dropped at the next container start |
+| `/app/.healthcheck-update-grace` | Auto-generated: bookkeeping for the health check's update exemption |
 | `/app/arkmanager` | Persisted arkmanager configuration (global + instance). `instances/sub.*.cfg` are auto-regenerated on every start |
 | `/app/Game.ini`, `/app/GameUserSettings.ini` | Convenience symlinks to the real config files (dangling until the server has written them once) |
 
@@ -658,6 +708,10 @@ The bundled [graceful shutdown](#graceful-shutdown) warns, saves and stops
 target `@all` — especially for updates: `arkmanager update @all --warn`
 stops and restarts every instance, while an update of a single instance
 would swap the shared server binaries underneath the still-running others.
+
+Stopping instances by hand shows up in the [health check](#health-check): the
+container stays healthy as long as one instance is running, and reports
+unhealthy about five minutes after the last one is gone.
 
 ### Example: 3 maps in 1 container
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,59 @@ value as "on", so this image only ever forwards an exact `true`, and the
 container refuses to start on anything else rather than let `True` or `yes` look
 accepted and do nothing.
 
+### Health check
+
+The image ships a `HEALTHCHECK`, so `docker ps` reports `healthy` / `unhealthy`
+and Kubernetes or Swarm have something to build a probe on. It asks
+`arkmanager status` about every instance this container manages (`main` plus one
+`sub.<KEY>` per entry in `SUB_INSTANCE_KEYS`) and fails as soon as one of them
+has no running server process.
+
+Defaults baked into the image:
+
+| Option | Default | Meaning |
+|---|---|---|
+| `--interval` | `1m` | Time between two checks |
+| `--timeout` | `30s` | A check that takes longer counts as failed |
+| `--start-period` | `5m` | Failures during this window after container start are not counted |
+| `--retries` | `5` | Consecutive failures before the container is marked `unhealthy` |
+
+So an instance has to be gone for about five minutes before the container turns
+unhealthy. That is on purpose: arkmanager restarts a crashed server on its own,
+and a restart plus map load can easily take a minute or two.
+
+Override the timings per container (compose):
+
+```yaml
+services:
+  server:
+    healthcheck:
+      interval: 5m
+      timeout: 30s
+      start_period: 10m
+      retries: 3
+```
+
+With plain `docker run` use `--health-interval=5m --health-timeout=30s
+--health-start-period=10m --health-retries=3`. To switch the check off entirely,
+use `healthcheck: disable: true` in compose or `--no-healthcheck` with
+`docker run`.
+
+The first start is not covered by `--start-period` but by the check itself: the
+initial download is roughly 25GB, which is 20 minutes on a fast line and half a
+day on a slow one, so no fixed start period fits everyone. Instead the entrypoint
+writes `/app/running-instances` right before it launches the servers, and the
+check only demands a running process for the instances listed in that file.
+While the file is missing (install, mod downloads, `UPDATE_ON_START`) the
+container counts as healthy, and the same goes for the window in which arkmanager
+holds its update lock, e.g. during a cron update that stops the server for a
+while.
+
+The check does not probe the game port. arkmanager's run loop already watches
+that and restarts an instance that stopped listening for 60 seconds, so failing
+the health check on it would report unhealthy exactly while the recovery is
+running.
+
 ### Data layout
 
 Everything the server needs lives in the volume mounted at `/app`
@@ -266,6 +319,7 @@ Everything the server needs lives in the volume mounted at `/app`
 | `/app/staging` | Staging directory arkmanager downloads updates into, see [staged updates](#staged-updates) |
 | `/app/crontab` | Cron definitions loaded at container start |
 | `/app/environment` | Auto-generated on every start: container environment for cron jobs (contains credentials, mode 600) |
+| `/app/running-instances` | Auto-generated: the instances the [health check](#health-check) watches. Missing while the container is still installing or updating |
 | `/app/arkmanager` | Persisted arkmanager configuration (global + instance). `instances/sub.*.cfg` are auto-regenerated on every start |
 | `/app/Game.ini`, `/app/GameUserSettings.ini` | Convenience symlinks to the real config files (dangling until the server has written them once) |
 

--- a/README.md
+++ b/README.md
@@ -269,8 +269,14 @@ instance this container manages (`main` plus one `sub.<KEY>` per entry in
 * **failing** (so `starting`, see below) while the container is still installing,
   updating or has not launched the servers yet
 
-Healthy means the server processes are up, not that players can already join. An
-instance that is loading a map has a process but no open port for a few minutes.
+**Healthy is not "ready for players".** It means the install is done and a server
+process is up, and loading the map takes minutes on top of that. On a test run
+the container went healthy about 10 minutes into a fresh install while the log
+had not printed `Server is up` yet, and on an existing install it went healthy
+within seconds of the container start with the map taking another 85 seconds. So
+`depends_on: condition: service_healthy` can start a dependent service minutes
+before the first player can connect. Anything that needs a reachable server
+should retry instead of trusting the gate.
 
 Defaults baked into the image:
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -6,6 +6,11 @@ set -e
 
 mkdir -p "${ARK_SERVER_VOLUME}" "/cluster"
 
+# drop healthcheck state from a previous container before anything slow runs:
+# the chown below can take many minutes on a 25GB volume, and until the file is
+# gone the healthcheck would judge this container by the last run's instances
+rm -f "${ARK_SERVER_VOLUME}/running-instances" "${ARK_SERVER_VOLUME}/.healthcheck-update-grace"
+
 # Optionally remap the steam user to a custom UID/GID, e.g. to match the
 # owner of a bind mount on NAS systems (Synology, UGREEN, ...)
 if [[ -n "${PUID}${PGID}" ]]; then

--- a/bin/healthcheck.sh
+++ b/bin/healthcheck.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ "$(id -u)" == "0" ]]; then
+  exec gosu "${STEAM_USER}" "${0}" "$@"
+fi
+
+ARKMANAGER="$(command -v arkmanager)"
+RUNNING_INSTANCES_FILE="${ARK_SERVER_VOLUME}/running-instances"
+UPDATE_LOCK_FILE="${ARK_SERVER_VOLUME}/server/ShooterGame/Saved/.ark-update.lock"
+
+function update_in_progress() {
+  local LOCK_PID
+
+  [[ -f "${UPDATE_LOCK_FILE}" ]] || return 1
+
+  # the lock survives a hard container kill, so trust it only while the
+  # process that took it is still alive (same check arkmanager does)
+  LOCK_PID="$(<"${UPDATE_LOCK_FILE}")"
+  [[ -n "${LOCK_PID}" ]] && kill -0 "${LOCK_PID}" 2>/dev/null
+}
+
+function instance_is_running() {
+  # stop reading after the 'Server running' line: below it arkmanager queries
+  # api.ipify.org and the Steam API, and a hiccup there must not make a
+  # perfectly fine server look unhealthy
+  "${ARKMANAGER}" status "@${1}" </dev/null 2>/dev/null | grep -qE 'Server running:.*Yes'
+}
+
+if [[ ! -f "${RUNNING_INSTANCES_FILE}" ]]; then
+  echo "healthy: no instance started yet (installing or updating)"
+  exit 0
+fi
+
+if update_in_progress; then
+  echo "healthy: arkmanager is updating the server"
+  exit 0
+fi
+
+STOPPED_INSTANCES=()
+while read -r INSTANCE; do
+  [[ -n "${INSTANCE}" ]] || continue
+  instance_is_running "${INSTANCE}" || STOPPED_INSTANCES+=("${INSTANCE}")
+done < "${RUNNING_INSTANCES_FILE}"
+
+if [[ ${#STOPPED_INSTANCES[@]} -gt 0 ]]; then
+  echo "unhealthy: no server process for instance(s): ${STOPPED_INSTANCES[*]}"
+  exit 1
+fi
+
+echo "healthy: all instances are running"

--- a/bin/healthcheck.sh
+++ b/bin/healthcheck.sh
@@ -15,8 +15,8 @@ ARKMANAGER="$(command -v arkmanager)"
 ARK_TOOLS_CONFIG_DIR="${ARK_TOOLS_DIR:-/etc/arkmanager}"
 RUNNING_INSTANCES_FILE="${ARK_SERVER_VOLUME}/running-instances"
 UPDATE_GRACE_MARKER="${ARK_SERVER_VOLUME}/.healthcheck-update-grace"
-STATUS_TIMEOUT="10s"
-STATUS_KILL_AFTER="5s"
+STATUS_TIMEOUT_SECONDS="10"
+STATUS_KILL_AFTER_SECONDS="5"
 
 UPDATE_GRACE_MINUTES="${HEALTHCHECK_UPDATE_GRACE_MINUTES:-30}"
 if [[ ! "${UPDATE_GRACE_MINUTES}" =~ ^[0-9]+$ ]]; then
@@ -71,13 +71,38 @@ function within_update_grace() {
   (( NOW - SINCE <= UPDATE_GRACE_MINUTES * 60 ))
 }
 
+# arkmanager's status forks lsof and perl, and past the line we read it calls
+# api.ipify.org and the Steam API without a timeout. 'timeout' would signal the
+# command but not reliably its children, which leaves one set of them behind per
+# probe, so the call runs as its own process group ('set -m') and the watchdog
+# signals the whole group. The pipe into grep usually ends arkmanager before it
+# reaches the http calls, but that is an optimization, not the guarantee.
 function instance_is_running() {
-  # the pipe usually ends arkmanager right after the line below, but that is an
-  # optimization, not a guarantee: further down it calls api.ipify.org and the
-  # Steam API without a timeout, so bound the whole thing from the outside
-  timeout -k "${STATUS_KILL_AFTER}" "${STATUS_TIMEOUT}" \
-    "${ARKMANAGER}" status "@${1}" </dev/null 2>/dev/null |
-    grep -qE 'Server running:.*Yes'
+  local STATUS_PID WATCHDOG_PID RESULT
+
+  set -m
+  { "${ARKMANAGER}" status "@${1}" </dev/null 2>/dev/null | grep -qE 'Server running:.*Yes'; } &
+  STATUS_PID=$!
+  {
+    sleep "${STATUS_TIMEOUT_SECONDS}"
+    kill -TERM -- "-${STATUS_PID}" 2>/dev/null
+    sleep "${STATUS_KILL_AFTER_SECONDS}"
+    kill -KILL -- "-${STATUS_PID}" 2>/dev/null
+  } &
+  WATCHDOG_PID=$!
+  set +m
+
+  wait "${STATUS_PID}" 2>/dev/null
+  RESULT=$?
+
+  # the pipeline ending does not mean arkmanager is gone: the group signal that
+  # ended it can be ignored by the command itself, and on a match grep leaves
+  # while arkmanager still runs. Sweep the group before calling the watchdog off
+  kill -KILL -- "-${STATUS_PID}" 2>/dev/null
+  kill -KILL -- "-${WATCHDOG_PID}" 2>/dev/null
+  wait "${WATCHDOG_PID}" 2>/dev/null
+
+  return "${RESULT}"
 }
 
 # 'main' is always the first entry, so an empty or half written file (out of

--- a/bin/healthcheck.sh
+++ b/bin/healthcheck.sh
@@ -2,51 +2,129 @@
 
 set -e
 
+if [[ "${DISABLE_HEALTHCHECK}" == "true" ]]; then
+  echo "healthy: disabled via DISABLE_HEALTHCHECK"
+  exit 0
+fi
+
 if [[ "$(id -u)" == "0" ]]; then
   exec gosu "${STEAM_USER}" "${0}" "$@"
 fi
 
 ARKMANAGER="$(command -v arkmanager)"
+ARK_TOOLS_CONFIG_DIR="${ARK_TOOLS_DIR:-/etc/arkmanager}"
 RUNNING_INSTANCES_FILE="${ARK_SERVER_VOLUME}/running-instances"
-UPDATE_LOCK_FILE="${ARK_SERVER_VOLUME}/server/ShooterGame/Saved/.ark-update.lock"
+UPDATE_GRACE_MARKER="${ARK_SERVER_VOLUME}/.healthcheck-update-grace"
+STATUS_TIMEOUT="10s"
+STATUS_KILL_AFTER="5s"
 
-function update_in_progress() {
-  local LOCK_PID
+UPDATE_GRACE_MINUTES="${HEALTHCHECK_UPDATE_GRACE_MINUTES:-30}"
+if [[ ! "${UPDATE_GRACE_MINUTES}" =~ ^[0-9]+$ ]]; then
+  echo "WARNING: HEALTHCHECK_UPDATE_GRACE_MINUTES='${UPDATE_GRACE_MINUTES}' is not a number, falling back to 30"
+  UPDATE_GRACE_MINUTES=30
+fi
 
-  [[ -f "${UPDATE_LOCK_FILE}" ]] || return 1
+function resolve_update_lock_file() {
+  (
+    # these files are edited by users and may well end on a failing test, which
+    # must not cost the update exemption
+    set +e
 
-  # the lock survives a hard container kill, so trust it only while the
-  # process that took it is still alive (same check arkmanager does)
+    for CONFIG in "${ARK_TOOLS_CONFIG_DIR}/arkmanager.cfg" "${HOME}/.arkmanager.cfg" "${ARK_TOOLS_CONFIG_DIR}/instances/main.cfg"; do
+      if [[ -r "${CONFIG}" ]]; then
+        # shellcheck source=/dev/null
+        source "${CONFIG}"
+      fi
+    done
+
+    [[ -n "${arkserverroot}" ]] || exit 1
+    printf '%s/%s\n' "${arkserverroot}" "${arkupdatelockfile:-${arkserverdir:-ShooterGame}/Saved/.ark-update.lock}"
+  ) 2>/dev/null
+}
+
+function update_lock_held() {
+  local LOCK_PID LOCK_CMDLINE
+
+  [[ -n "${UPDATE_LOCK_FILE}" ]] && [[ -s "${UPDATE_LOCK_FILE}" ]] || return 1
+
   LOCK_PID="$(<"${UPDATE_LOCK_FILE}")"
-  [[ -n "${LOCK_PID}" ]] && kill -0 "${LOCK_PID}" 2>/dev/null
+  [[ "${LOCK_PID}" =~ ^[0-9]+$ ]] || return 1
+
+  # upstream only checks that the pid is alive, which a recycled pid also is -
+  # believing a recycled one would keep this check green for good
+  LOCK_CMDLINE="$(tr -d '\0' 2>/dev/null < "/proc/${LOCK_PID}/cmdline" || true)"
+  [[ "${LOCK_CMDLINE}" == *arkmanager* ]]
+}
+
+function within_update_grace() {
+  local NOW SINCE
+
+  NOW="$(date +%s)"
+  if [[ -s "${UPDATE_GRACE_MARKER}" ]]; then
+    SINCE="$(<"${UPDATE_GRACE_MARKER}")"
+  else
+    SINCE="${NOW}"
+    echo "${SINCE}" > "${UPDATE_GRACE_MARKER}" || return 1
+  fi
+
+  [[ "${SINCE}" =~ ^[0-9]+$ ]] || return 1
+  (( NOW - SINCE <= UPDATE_GRACE_MINUTES * 60 ))
 }
 
 function instance_is_running() {
-  # stop reading after the 'Server running' line: below it arkmanager queries
-  # api.ipify.org and the Steam API, and a hiccup there must not make a
-  # perfectly fine server look unhealthy
-  "${ARKMANAGER}" status "@${1}" </dev/null 2>/dev/null | grep -qE 'Server running:.*Yes'
+  # the pipe usually ends arkmanager right after the line below, but that is an
+  # optimization, not a guarantee: further down it calls api.ipify.org and the
+  # Steam API without a timeout, so bound the whole thing from the outside
+  timeout -k "${STATUS_KILL_AFTER}" "${STATUS_TIMEOUT}" \
+    "${ARKMANAGER}" status "@${1}" </dev/null 2>/dev/null |
+    grep -qE 'Server running:.*Yes'
 }
 
-if [[ ! -f "${RUNNING_INSTANCES_FILE}" ]]; then
-  echo "healthy: no instance started yet (installing or updating)"
-  exit 0
-fi
-
-if update_in_progress; then
-  echo "healthy: arkmanager is updating the server"
-  exit 0
-fi
-
-STOPPED_INSTANCES=()
-while read -r INSTANCE; do
-  [[ -n "${INSTANCE}" ]] || continue
-  instance_is_running "${INSTANCE}" || STOPPED_INSTANCES+=("${INSTANCE}")
-done < "${RUNNING_INSTANCES_FILE}"
-
-if [[ ${#STOPPED_INSTANCES[@]} -gt 0 ]]; then
-  echo "unhealthy: no server process for instance(s): ${STOPPED_INSTANCES[*]}"
+# 'main' is always the first entry, so an empty or half written file (out of
+# disk) cannot pass as a complete instance list
+if [[ ! -s "${RUNNING_INSTANCES_FILE}" ]] || ! grep -qx "main" "${RUNNING_INSTANCES_FILE}"; then
+  echo "not ready: no instances launched yet (installing, updating, or out of disk)"
   exit 1
 fi
 
-echo "healthy: all instances are running"
+INSTANCES=()
+while read -r INSTANCE; do
+  [[ -n "${INSTANCE}" ]] || continue
+  INSTANCES+=("${INSTANCE}")
+done < "${RUNNING_INSTANCES_FILE}"
+
+UPDATE_LOCK_FILE="$(resolve_update_lock_file || true)"
+if update_lock_held; then
+  UPDATE_IN_PROGRESS="true"
+else
+  UPDATE_IN_PROGRESS="false"
+  rm -f "${UPDATE_GRACE_MARKER}"
+fi
+
+RUNNING_INSTANCES=()
+STOPPED_INSTANCES=()
+for INSTANCE in "${INSTANCES[@]}"; do
+  if instance_is_running "${INSTANCE}"; then
+    RUNNING_INSTANCES+=("${INSTANCE}")
+  else
+    STOPPED_INSTANCES+=("${INSTANCE}")
+  fi
+done
+
+if [[ ${#STOPPED_INSTANCES[@]} -eq 0 ]]; then
+  echo "healthy: running ${RUNNING_INSTANCES[*]}"
+  exit 0
+fi
+
+if [[ ${#RUNNING_INSTANCES[@]} -gt 0 ]] && [[ "${HEALTHCHECK_REQUIRE_ALL_INSTANCES}" != "true" ]]; then
+  echo "healthy: running ${RUNNING_INSTANCES[*]} - not running ${STOPPED_INSTANCES[*]}"
+  exit 0
+fi
+
+if [[ "${UPDATE_IN_PROGRESS}" == "true" ]] && within_update_grace; then
+  echo "healthy: arkmanager is updating - not running ${STOPPED_INSTANCES[*]}"
+  exit 0
+fi
+
+echo "unhealthy: no server process for ${STOPPED_INSTANCES[*]}"
+exit 1

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -35,10 +35,6 @@ function stop_server() {
 
   echo "Caught stop signal, gracefully stopping all ARK server instances..."
 
-  # the instances go down on purpose - do not let the healthcheck flag the
-  # world save, which may well take minutes, as a failure
-  rm -f "${RUNNING_INSTANCES_FILE}"
-
   if [[ "${WARN_ON_STOP}" == "true" ]]; then
     ${ARKMANAGER} broadcast @all "Server is shutting down" || true
   fi
@@ -632,6 +628,21 @@ function heal_config_symlinks() {
   done
 }
 
+# the healthcheck expects every instance listed in this file to have a running
+# server process, so it is only written once they are about to start. The temp
+# file matters: a truncated list (out of disk) would tell the healthcheck that
+# fewer instances are supposed to run than really are
+function write_running_instances() {
+  local TARGET="${ARK_SERVER_VOLUME}/running-instances"
+
+  if ! { printf '%s\n' "${@}" > "${TARGET}.tmp" && mv -f "${TARGET}.tmp" "${TARGET}"; }; then
+    rm -f "${TARGET}.tmp"
+    echo "WARNING: could not write ${TARGET}, the container will report unhealthy..."
+
+    return 1
+  fi
+}
+
 # everything below is the startup sequence; sourcing this script (the test
 # suite does) only defines the functions above
 if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
@@ -707,12 +718,6 @@ ARKMANAGER="$(command -v arkmanager)" || true
 )
 
 cd "${ARK_SERVER_VOLUME}"
-
-# the healthcheck expects every instance listed in this file to have a running
-# server process - drop it for the whole bootstrap phase (install, mod
-# download, update on start), which may legitimately take hours
-RUNNING_INSTANCES_FILE="${ARK_SERVER_VOLUME}/running-instances"
-rm -f "${RUNNING_INSTANCES_FILE}"
 
 # export the container environment for cron jobs (minus shell bookkeeping):
 # the bundled crontab loads it via BASH_ENV so that arkmanager and its
@@ -812,9 +817,13 @@ ARK_RUN_PIDS=()
 trap stop_server TERM INT
 
 # remove state files left behind if a previous shutdown did not complete in
-# time (the glob also covers upstream's per-instance .autorestart-<name>)
+# time (the glob also covers upstream's per-instance .autorestart-<name>).
+# The update lock has to go too: no update can be running this early, and once
+# the kernel hands its recorded pid to another process, arkmanager aborts every
+# start with "An update is currently in progress"
 rm -f "${ARK_SERVER_VOLUME}/server/ShooterGame/Saved/".*.pid \
-      "${ARK_SERVER_VOLUME}/server/ShooterGame/Saved/".autorestart*
+      "${ARK_SERVER_VOLUME}/server/ShooterGame/Saved/".autorestart* \
+      "${ARK_SERVER_VOLUME}/server/ShooterGame/Saved/".ark-update.lock*
 
 # arkmanager only copies arkGameUserSettingsIniFile/arkGameIniFile over the
 # save dir config in its 'start' path, and we run 'run' to stay PID 1 - so do
@@ -828,8 +837,7 @@ for INSTANCE in "${INSTANCES[@]}"; do
     "${CONFIG_DIR}/Game.ini" "${INSTANCE}"
 done
 
-printf '%s\n' "${INSTANCES[@]}" > "${RUNNING_INSTANCES_FILE}" ||
-  echo "WARNING: could not write ${RUNNING_INSTANCES_FILE}, the container healthcheck will always report healthy..."
+write_running_instances "${INSTANCES[@]}" || true
 
 for INSTANCE in "${INSTANCES[@]}"; do
   echo "Running instance ${INSTANCE} ..."

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -35,6 +35,10 @@ function stop_server() {
 
   echo "Caught stop signal, gracefully stopping all ARK server instances..."
 
+  # the instances go down on purpose - do not let the healthcheck flag the
+  # world save, which may well take minutes, as a failure
+  rm -f "${RUNNING_INSTANCES_FILE}"
+
   if [[ "${WARN_ON_STOP}" == "true" ]]; then
     ${ARKMANAGER} broadcast @all "Server is shutting down" || true
   fi
@@ -704,6 +708,12 @@ ARKMANAGER="$(command -v arkmanager)" || true
 
 cd "${ARK_SERVER_VOLUME}"
 
+# the healthcheck expects every instance listed in this file to have a running
+# server process - drop it for the whole bootstrap phase (install, mod
+# download, update on start), which may legitimately take hours
+RUNNING_INSTANCES_FILE="${ARK_SERVER_VOLUME}/running-instances"
+rm -f "${RUNNING_INSTANCES_FILE}"
+
 # export the container environment for cron jobs (minus shell bookkeeping):
 # the bundled crontab loads it via BASH_ENV so that arkmanager and its
 # bash-based config files see the same variables as the server process
@@ -817,6 +827,9 @@ for INSTANCE in "${INSTANCES[@]}"; do
   apply_ini_file "$(ini_file_for_instance "${INSTANCE}" ARK_GAME_INI_FILE)" \
     "${CONFIG_DIR}/Game.ini" "${INSTANCE}"
 done
+
+printf '%s\n' "${INSTANCES[@]}" > "${RUNNING_INSTANCES_FILE}" ||
+  echo "WARNING: could not write ${RUNNING_INSTANCES_FILE}, the container healthcheck will always report healthy..."
 
 for INSTANCE in "${INSTANCES[@]}"; do
   echo "Running instance ${INSTANCE} ..."

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -10,6 +10,15 @@ services:
     # Give the server enough time to broadcast, save the world and shut down
     # gracefully before docker sends SIGKILL (default would be 10s)
     stop_grace_period: 5m
+    # The image brings its own health check (see the README section "Health
+    # check"). It stays "starting" until the servers are up, which on a fresh
+    # volume includes the ~25GB download. Uncomment to change the timings or
+    # to switch it off.
+    #healthcheck:
+    #  interval: 1m
+    #  timeout: 45s
+    #  start_period: 6h
+    #  retries: 5
     # If you want to build from fresh source every "docker-compose up" ...
     # ... remove the "image:"-key and uncomment the following two lines:
     #build:
@@ -45,6 +54,9 @@ services:
       # Restart an instance that crashes before it finished starting,
       # see the README section "Crash restarts" first, this can loop
       - ALWAYS_RESTART_ON_CRASH=${ALWAYS_RESTART_ON_CRASH:-}
+      # # Health check behaviour, see the README section "Health check"
+      #- DISABLE_HEALTHCHECK=true
+      #- HEALTHCHECK_REQUIRE_ALL_INSTANCES=true
       # # Cluster / multi-map settings, see the README section
       # # "Cluster and multi-map support" for all SUB_<KEY>_* variables
       #- CLUSTER_ID=MyCluster

--- a/tests/running_instances.bats
+++ b/tests/running_instances.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+load helper
+
+setup() {
+  load_entrypoint
+
+  RUNNING_INSTANCES="${ARK_SERVER_VOLUME}/running-instances"
+}
+
+@test "writes one instance per line" {
+  write_running_instances main sub.Fjordur sub.Caballus_P
+
+  [ "$(cat "${RUNNING_INSTANCES}")" = "$(printf 'main\nsub.Fjordur\nsub.Caballus_P')" ]
+}
+
+@test "leaves no temp file behind" {
+  write_running_instances main
+
+  [ ! -e "${RUNNING_INSTANCES}.tmp" ]
+}
+
+@test "replaces the list of an earlier run" {
+  printf 'main\nsub.Ghost\n' > "${RUNNING_INSTANCES}"
+
+  write_running_instances main
+
+  [ "$(cat "${RUNNING_INSTANCES}")" = "main" ]
+}
+
+@test "fails and warns when the volume cannot be written" {
+  export ARK_SERVER_VOLUME="${BATS_TEST_TMPDIR}/missing/volume"
+
+  run write_running_instances main
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "will report unhealthy"
+  [ ! -e "${BATS_TEST_TMPDIR}/missing/volume/running-instances" ]
+}
+
+@test "keeps the previous list when the write fails" {
+  printf 'main\n' > "${RUNNING_INSTANCES}"
+  # a directory in the way fails the write for root as well
+  mkdir -p "${RUNNING_INSTANCES}.tmp"
+
+  run write_running_instances main sub.Fjordur
+
+  [ "$status" -eq 1 ]
+  [ "$(cat "${RUNNING_INSTANCES}")" = "main" ]
+}
+
+@test "writes the list without calling arkmanager or steamcmd" {
+  write_running_instances main
+
+  assert_stubs_installed_and_unused
+}


### PR DESCRIPTION
Adds a `HEALTHCHECK` to the image. `docker ps` shows `starting` / `healthy` / `unhealthy`. New `bin/healthcheck.sh` runs as root, drops to the steam user with gosu and asks `arkmanager status` about every instance the container manages (`main` plus the `sub.<KEY>` ones from `SUB_INSTANCE_KEYS`).

`healthy` means the install finished and a server process is up, not that the map is loaded and players can join. Measured on a real host: a fresh install goes healthy about 10 minutes in while the map is still loading, an existing install within seconds of container start with the map taking another 85 seconds. `depends_on: condition: service_healthy` can therefore start a dependent service minutes before the first player can connect, so anything that needs a reachable server should retry rather than trust the gate. That is in the README now.

Defaults: `--interval=1m --timeout=45s --start-period=6h --retries=5`, all documented in the README together with the compose and `docker run` overrides, plus `DISABLE_HEALTHCHECK=true` for Portainer, Unraid and Synology UIs that do not expose `--no-healthcheck`.

**Bootstrap fails the check, it does not pass it.** A fresh container downloads roughly 25GB, so my first version reported healthy while nothing was running. That is wrong for the most common use of a health check: `depends_on: condition: service_healthy` would unblock a second service a second after start, and a Swarm rolling update would call the task converged. Docker already has the right state for this. Measured on 29.7.2: a container that fails inside `--start-period` stays `starting` and its `FailingStreak` stays at 0 (7 consecutive failures with `--health-retries=2`), the first success ends the start period early, and failures after that success count normally and flip it to `unhealthy` even though the nominal start period is still running. So the start period is 6h and a real outage is still caught five minutes after the servers were last up.

**Health is judged per container, not per instance.** `doRun` only arms auto restart after the server has listened once, so a sub instance that dies while loading (bad map mod) is gone for good. Failing the whole container on it means autoheal or Swarm bounce it on a fixed cycle and cut off saves on the maps that were fine, while before this PR the outcome was simply one map down and two up. Default is now unhealthy only when no managed instance is running, with the dead one named in the health log. `HEALTHCHECK_REQUIRE_ALL_INSTANCES=true` gives the strict behaviour for people who want it.

**The update lock exemption is bounded and no longer trusts a recycled pid.** The lock belongs to the server directory, not to an instance, and `doUpdate` takes it before the warn countdown, so with the crontab the image ships that is over an hour of blanket "healthy" every night. It is now capped by `HEALTHCHECK_UPDATE_GRACE_MINUTES` (default 30), counted from the moment the check actually starts excusing something rather than from the lock's creation, so the countdown does not eat the budget and a crash during the update window still surfaces. The lock path comes from arkmanager's own config chain now instead of being hardcoded, so moving `arkserverroot` does not silently lose the exemption. The entrypoint deletes the lock at container start, next to the pid and autorestart cleanup: no update can be running at that point, and once the kernel hands the recorded pid to another steam owned process, `doRun` aborts every instance with "An update is currently in progress" while the probe would have reported healthy forever. The check additionally requires the lock's pid to actually be an arkmanager process.

**Nothing fails open any more.** Missing, empty or truncated `/app/running-instances` (the normal end state of a full ARK volume, `printf > file` truncates before it can fail) now fails instead of reporting "all instances are running". `main` is always the first entry, so requiring the file to contain it catches both the empty and the partial write, and the entrypoint writes through a temp file so a partial list cannot appear in the first place. Same for an unresolvable `arkserverroot` or a missing arkmanager. The stale state file is dropped in the root entrypoint before the recursive chown, because a NAS user setting `PUID` for the first time can spend more than the whole health budget in that chown.

**The pipe is the optimization, the process group is the guarantee.** `arkmanager status` calls api.ipify.org and the Steam API without a timeout right after the line the check needs. Piping into `grep -q` usually ends it before that, but only because `isTheServerUp` forks `which` and `lsof` between two echoes, and the pipe buffer happily absorbs the whole output otherwise. My stub reproduces exactly that: the "network part" marker gets written every run. CI resolves ark-server-tools master at build time, so an upstream reorder would turn every probe into two untimed curls, and Docker's own timeout records a failed probe without reaping the exec. The call has to be bounded from the outside.

`timeout` alone does not do that. It signals the command it started, but not reliably what that command forked, so a probe that gave up on a hung arkmanager left the children running: measured on a real host, two survivors, one per instance, still alive eight seconds after the probe returned. At a one minute interval that accumulates for as long as the server is wedged. The status call now runs as its own process group (`set -m`) with a watchdog that signals the group, TERM and then KILL, and the group is swept with KILL once the pipeline is done. The sweep is the part that matters: the group TERM ends our own pipeline first, so without it the watchdog gets called off before it can escalate and anything that ignores TERM stays behind. It also cleans up the case where grep matched and left while arkmanager was still in its http calls.

This one is measured, not taken from the coreutils docs. Against a fake arkmanager that ignores TERM, with three instances, five probes in a row leave zero survivors counted in `/proc`, and four probes through a real docker `HEALTHCHECK` (started as root, dropping privileges first) leave zero as well. The same test against the old shape counts 1, then 4, then 7, so the assertion bites. Confirmed on a real host with a live server too: nothing accumulates over four probes and nothing is left after 60 seconds idle, the healthy path still returns in under a second, a hung arkmanager reports unhealthy after the timeout, and the server itself is untouched afterwards.

Per instance timeout 10s, image timeout 45s, so raise the latter if you run more than four maps in one container.

**No port probing**, unchanged from the first round: arkmanager's run loop already restarts an instance that stopped listening for 60 seconds, so failing on the same signal would report unhealthy exactly while that recovery runs.

Kubernetes ignores an image `HEALTHCHECK` entirely, so the README no longer claims otherwise and shows the startup and liveness probes to write instead, with the same timings.

The write of the state file is a `write_running_instances` helper above the `BASH_SOURCE` guard, so the bats suite covers it: `bats tests` is at 80 passing, 6 of them new (one line per instance, no temp file left behind, replacing an earlier run's list, and the two failure paths where the write cannot happen and the previous list has to survive).

The healthcheck itself is covered by a 34 assertion smoke test with a stubbed arkmanager, run in a Debian container so `/proc` and process groups behave like they do in the image: bootstrap and truncated state files, single instance up and down, a hung arkmanager and a hung one that ignores TERM with survivor counts after repeated probes, one dead map out of three in both modes, live lock, expired grace, dead pid, recycled pid, foreign pid, empty lock, unresolvable server root and the opt out. Plus `bash -n` and the pinned shellcheck from the lint workflow, both clean. No image build, that pulls 25GB.

Rebased on current master (#172, #168, #167).

Closes #154
