### PR TITLE
Pin the server install to a Steam manifest id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,8 +214,9 @@ downstream compose files and scripts.
   the directory setup, the cluster config guard, the Discord config migration
   and its hardcoded webhook warning, the disk space check, the appended
   arkmanager.cfg blocks, the backup budget and crash restart validation, the
-  `running-instances` state file the healthcheck reads). It never installs a
-  server, arkmanager and steamcmd are stubbed in `tests/stubs`.
+  `running-instances` state file the healthcheck reads, the manifest pin
+  bookkeeping). It never installs a server, arkmanager and steamcmd are
+  stubbed in `tests/stubs`.
 - **Writing tests:** assert with `[ ... ]` or the helpers in
   `tests/helper.bash`, never with `[[ ... ]]`. macOS ships bash 3.2, where a
   failing non-final `[[ ... ]]` does not fail the test, so those assertions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,22 @@ downstream compose files and scripts.
     silently deliver the current build instead. The install verifies the
     manifest steamcmd reports and the `depotcache/<depot>_<manifest>.manifest`
     it leaves behind, and refuses to copy anything it cannot confirm.
+  - Verified against real steamcmd on Linux, do not "simplify" these away:
+    - **`download_depot` needs a real Steam login.** Anonymous gets
+      `missing license for depot (No subscription)` for depot 376031, although
+      `app_update 376030` works anonymously. The entrypoint refuses to start
+      with a pin and an anonymous `STEAM_LOGIN`.
+    - **`+app_info_update 1` alone is not enough**, only a following
+      `+app_info_print <appid>` puts the app info in the cache that
+      `download_depot` needs. Without it the first pinned install in a fresh
+      container dies with `missing app info (Missing configuration)`.
+    - **The path in the completion line is unusable**, it comes out as
+      `"/home/steam/steamcmd/linux32\steamapps\content\app_376030\depot_1006"`
+      with mixed separators. Read only the manifest id from that line and
+      locate the directory with `find`.
+    - **The depot lands under `/home/steam/steamcmd/linux32/steamapps/...`**,
+      not under `${STEAM_HOME}/Steam`, so the disk gate measures the steamcmd
+      directory. A mounted Steam session volume never holds the staging copy.
 - Keep entrypoint/runtime behavior and documented environment variables
   backward compatible; users run long-lived servers against `latest`.
 - **`bin/steam-entrypoint.sh` is sourceable.** Everything above the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,14 @@ downstream compose files and scripts.
   probe piles up into hundreds an hour. That is why the call runs as its own
   process group and the group is signalled, instead of `timeout` alone, which
   signals the command but not reliably what the command forked.
+- **`TARGET_MANIFEST_ID` bypasses arkmanager on purpose.** arkmanager can only
+  ever update to the newest build (steamcmd's `app_update` takes no manifest
+  argument, and arkmanager has no `download_depot` support), so a pinned
+  install calls `steamcmd +download_depot` directly and copies the depot into
+  the server directory. It then has to keep arkmanager away from steamcmd: the
+  entrypoint forces `UPDATE_ON_START=false`, which `conf.d/arkmanager.cfg`
+  binds to `arkAutoUpdateOnStart`, and which cron jobs also read via
+  `BASH_ENV`. Do not fold this back into an `arkmanager install/update` call.
 - Keep entrypoint/runtime behavior and documented environment variables
   backward compatible; users run long-lived servers against `latest`.
 - **`bin/steam-entrypoint.sh` is sourceable.** Everything above the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,10 +159,17 @@ downstream compose files and scripts.
   - Bypassing `app_update` means no `steamapps/appmanifest_376030.acf` is
     written and the depot ships no `version.txt`, so none of arkmanager's
     version bookkeeping describes a pinned install. `server/.ark_manifest_pin`
-    is the image's own record (pinned manifest plus the Steam build id at pin
-    time) and the only thing that proves a pinned install completed.
-  - A changed build id means something ran `app_update` behind the pin (a cron
-    `arkmanager update`); the next start detects that and re-applies the pin.
+    is the image's own record (pinned manifest, Steam build id and a `cksum` of
+    `ShooterGameServer` at pin time) and the only thing that proves a pinned
+    install completed.
+  - **Delete the pin file before the first copy, never only after the last
+    one.** Between the two copies the server directory holds a mix of two
+    builds; a pin file that survives an aborted swap makes the next start
+    report "Already installed" over half-swapped files.
+  - A changed build id or binary checksum means something replaced the pinned
+    files (a cron `arkmanager update`, a repair); the next start detects that
+    and re-applies the pin. The checksum covers only the server executable, not
+    the ~22GB of content, and the README says so.
   - Un-pinning deletes that stale bookkeeping so the normal install path runs a
     full validate back to the current build. Without it arkmanager reads a
     stale build id and calls the downgraded server up to date.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,10 +154,26 @@ downstream compose files and scripts.
   ever update to the newest build (steamcmd's `app_update` takes no manifest
   argument, and arkmanager has no `download_depot` support), so a pinned
   install calls `steamcmd +download_depot` directly and copies the depot into
-  the server directory. It then has to keep arkmanager away from steamcmd: the
-  entrypoint forces `UPDATE_ON_START=false`, which `conf.d/arkmanager.cfg`
-  binds to `arkAutoUpdateOnStart`, and which cron jobs also read via
-  `BASH_ENV`. Do not fold this back into an `arkmanager install/update` call.
+  the server directory. Do not fold this back into an `arkmanager
+  install/update` call. Consequences worth knowing before touching that path:
+  - Bypassing `app_update` means no `steamapps/appmanifest_376030.acf` is
+    written and the depot ships no `version.txt`, so none of arkmanager's
+    version bookkeeping describes a pinned install. `server/.ark_manifest_pin`
+    is the image's own record (pinned manifest plus the Steam build id at pin
+    time) and the only thing that proves a pinned install completed.
+  - A changed build id means something ran `app_update` behind the pin (a cron
+    `arkmanager update`); the next start detects that and re-applies the pin.
+  - Un-pinning deletes that stale bookkeeping so the normal install path runs a
+    full validate back to the current build. Without it arkmanager reads a
+    stale build id and calls the downgraded server up to date.
+  - `arkmanager run` does **not** auto-update (`doRun` never calls `doUpdate`);
+    `start`/`restart` do, via `arkAutoUpdateOnStart`. Forcing
+    `UPDATE_ON_START=false` while pinned covers those and the cron environment,
+    it is not what holds the pin on a normal start.
+  - `download_depot` never learned Steam's 2021 manifest request codes and can
+    silently deliver the current build instead. The install verifies the
+    manifest steamcmd reports and the `depotcache/<depot>_<manifest>.manifest`
+    it leaves behind, and refuses to copy anything it cannot confirm.
 - Keep entrypoint/runtime behavior and documented environment variables
   backward compatible; users run long-lived servers against `latest`.
 - **`bin/steam-entrypoint.sh` is sourceable.** Everything above the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,9 +159,26 @@ downstream compose files and scripts.
   - Bypassing `app_update` means no `steamapps/appmanifest_376030.acf` is
     written and the depot ships no `version.txt`, so none of arkmanager's
     version bookkeeping describes a pinned install. `server/.ark_manifest_pin`
-    is the image's own record (pinned manifest, Steam build id and a `cksum` of
-    `ShooterGameServer` at pin time) and the only thing that proves a pinned
-    install completed.
+    is the image's own record (`manifest`, `buildid_at_pin` and
+    `binary_at_pin`, a `cksum` of `ShooterGameServer`) and the only thing that
+    proves a pinned install completed. The `_at_pin` suffixes are deliberate:
+    those two fields say nothing has replaced the server since the pin, they do
+    not identify which build is on disk.
+  - **The pinned install deletes `appmanifest_376030.acf`.** Steam's metadata
+    would otherwise keep describing the build the pin replaced, and the staged
+    update cron examples in the README compare exactly that file. Every update
+    job in `conf.d/crontab` and the README carries a
+    `[ -z "${TARGET_MANIFEST_ID}" ]` guard for the same reason; an update job
+    undoes the pin and the drift check only catches it at the next restart.
+  - **A missing redistributable depot is fatal** unless
+    `server/linux64/steamclient.so` is already installed. The server cannot
+    start without it, and writing the pin anyway would make every later start
+    report "Already installed" over an install that crash loops.
+  - **Kept staging is labelled with the manifest it was for.**
+    `download_depot` unpacks into `content/app_376030/depot_376031`, a path
+    with no manifest in it, so a partial download kept for one manifest would
+    otherwise be written over by the next one and handed on as verified. The
+    marker sits next to the depot directory, never inside it.
   - **Delete the pin file before the first copy, never only after the last
     one.** Between the two copies the server directory holds a mix of two
     builds; a pin file that survives an aborted swap makes the next start
@@ -215,8 +232,10 @@ downstream compose files and scripts.
   and its hardcoded webhook warning, the disk space check, the appended
   arkmanager.cfg blocks, the backup budget and crash restart validation, the
   `running-instances` state file the healthcheck reads, the manifest pin
-  bookkeeping). It never installs a server, arkmanager and steamcmd are
-  stubbed in `tests/stubs`.
+  bookkeeping, and `install_pinned_manifest` end to end against a steamcmd stub
+  that mimics the real one). It never installs a server, arkmanager and
+  steamcmd are stubbed in `tests/stubs`; `tests/pinned_install.bats` writes its
+  own steamcmd stub because the code calls it by absolute path.
 - **Writing tests:** assert with `[ ... ]` or the helpers in
   `tests/helper.bash`, never with `[[ ... ]]`. macOS ships bash 3.2, where a
   failing non-final `[[ ... ]]` does not fail the test, so those assertions

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ ENV         IMAGE_VERSION="${IMAGE_VERSION}" \
             ARK_SERVER_VOLUME="/app" \
             BETA="" \
             BETA_ACCESSCODE="" \
+            TARGET_MANIFEST_ID="" \
             TEMPLATE_DIRECTORY="/conf.d" \
             GAME_CLIENT_PORT="7777" \
             UDP_SOCKET_PORT="7778" \

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Basic configuration is done with environment variables:
 | UDP_SOCKET_PORT | 7778 | Raw UDP socket port (always game client port +1) |
 | RCON_PORT | 27020 | Exposed RCON port |
 | SERVER_LIST_PORT | 27015 | Exposed server-list (query) port |
-| SKIP_DISK_CHECK | false | Skip the free-disk-space check (~25GB) before installing the server files |
+| SKIP_DISK_CHECK | false | Skip the free-disk-space check before installing the server files (~25GB, ~50GB for a first install with `TARGET_MANIFEST_ID`) |
 | DISCORD_WEBHOOK_URL | `empty` | Discord webhook to notify on start, stop, crash and restart, see [Discord notifications](#discord-notifications) |
 | DISABLE_HEALTHCHECK | false | Set to `true` to make the [health check](#health-check) always report healthy, for UIs that do not expose `--no-healthcheck` |
 | HEALTHCHECK_REQUIRE_ALL_INSTANCES | false | Report unhealthy as soon as one instance is down, instead of only when all of them are, see [health check](#health-check) |
@@ -698,7 +698,14 @@ the one that broke.
 * An explicit `arkmanager update` (for example from one of the
   [crontab](#add-cronjobs) examples) still updates and undoes the pin. Comment
   those jobs out while you are pinned. If one runs anyway, the next start
-  notices the changed Steam build id, says so, and re-applies the pin.
+  notices, says so, and re-applies the pin.
+
+  What that check actually is: the image records the Steam build id and a
+  checksum of `ShooterGameServer` when it pins, and compares both on every
+  start. So it catches anything that replaces the server binary or Steam's
+  records. It does not checksum the other ~22GB, so a change limited to game
+  content with the binary left alone goes unnoticed. It is a tripwire for the
+  update paths that exist in this image, not a full integrity check.
 * A backup is taken before the server binaries are swapped, unless you set
   `PRE_UPDATE_BACKUP=false`. If the backup fails, the swap is refused: an older
   build rewrites the saves it loads on the first autosave.
@@ -730,10 +737,13 @@ of reach with `steamcmd` and no setting here helps.
 
 **Disk space:** `download_depot` ignores the install directory and always
 stages the full depot below `/home/steam` first, so a pinned install needs
-~25GB there on top of the ~25GB in the server volume, and on a normal Docker
-host both are the same disk, so ~50GB. The staging copy is removed as soon as
-it has been moved into place. If you mounted a Steam session volume at
-`/home/steam/Steam`, the staging copy may land there.
+~25GB there on top of the ~25GB in the server volume. On a normal Docker host
+both are the same disk, so the first pinned install wants ~50GB free and every
+later re-pin ~25GB. The staging copy is removed once it has been moved into
+place, and also when an install gives up, except for a download that was cut
+short, which is kept so a restart can resume it (the error names the directory
+and its size). If you mounted a Steam session volume at `/home/steam/Steam`,
+the staging copy may land there.
 
 ## Cluster and multi-map support
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Basic configuration is done with environment variables:
 | GAME_MOD_IDS | `empty` | Additional game mods to install, separated by comma (e.g. `GAME_MOD_IDS=487516323,487516324,487516325`) |
 | UPDATE_ON_START | false | Update the ARK server and mods (with a backup, if configured) before each start |
 | VALIDATE_ON_START | false | Let `steamcmd` validate and repair the server files during `UPDATE_ON_START` — useful after a corrupted update, but makes the start noticeably slower |
-| PRE_UPDATE_BACKUP | true | Create a backup before updating the ARK server |
+| PRE_UPDATE_BACKUP | true | Create a backup before updating the ARK server, and before a `TARGET_MANIFEST_ID` pin swaps the server binaries |
 | BACKUP_ON_STOP | false | Create a backup after the world save when the container is stopped gracefully |
 | MAX_BACKUP_SIZE_MB | `empty` | Size budget for `/app/backup`, in megabytes. arkmanager deletes the oldest backups once the directory grows past it, see [Backup retention](#backup-retention) |
 | WARN_ON_STOP | true | Broadcast a shutdown warning to players when the container is stopped gracefully |
@@ -679,26 +679,41 @@ join it.
 the build you want by date, and copy its manifest id (a long number). The
 `public` branch is the one a normal install uses.
 
+A whole cluster has to be pinned to the same manifest. Maps on different builds
+sharing one `/cluster` volume can corrupt transferred characters, dinos and
+items, so set `TARGET_MANIFEST_ID` on every container of the cluster, not just
+the one that broke.
+
 **What changes while a pin is set:**
 
 * `arkmanager` has no way to pass a manifest to `steamcmd`, so the install
   bypasses arkmanager and calls `steamcmd +download_depot` directly.
-* `UPDATE_ON_START` is ignored and arkmanager's own update-before-start is
-  switched off, otherwise the next restart would pull the broken build straight
-  back in. The container log says so on every start.
+* Updates are off. `UPDATE_ON_START` is ignored, and so is arkmanager's own
+  update-before-start (`arkmanager start`/`restart` from a cron job). The
+  container log says so on every start.
+* Mods are frozen too. A mod built for the current build usually does not load
+  on an older one, so freezing them next to the binaries is the point.
 * `BETA` is ignored. A manifest id already identifies exactly one build of one
   branch.
-* Mods are still installed and updated as usual.
 * An explicit `arkmanager update` (for example from one of the
-  [crontab](#add-cronjobs) examples) still updates. Comment those jobs out
-  while you are pinned.
+  [crontab](#add-cronjobs) examples) still updates and undoes the pin. Comment
+  those jobs out while you are pinned. If one runs anyway, the next start
+  notices the changed Steam build id, says so, and re-applies the pin.
+* A backup is taken before the server binaries are swapped, unless you set
+  `PRE_UPDATE_BACKUP=false`. If the backup fails, the swap is refused: an older
+  build rewrites the saves it loads on the first autosave.
 
-Change `TARGET_MANIFEST_ID` and restart to switch to a different build, or
-remove it to go back to normal updates. Switching from one pin to another
-copies the new build over the old one, it does not delete files the new build
-dropped. That is normally fine, but if a switched server misbehaves, back up
-`<your-volume>/server/ShooterGame/Saved`, delete `<your-volume>/server` and let
-it install again.
+Change `TARGET_MANIFEST_ID` and restart to switch to a different build.
+Switching from one pin to another copies the new build over the old one, it
+does not delete files the new build dropped. That is normally fine, but if a
+switched server misbehaves, back up `<your-volume>/server/ShooterGame/Saved`,
+delete `<your-volume>/server` and let it install again.
+
+**Getting back off a pin:** remove `TARGET_MANIFEST_ID` and restart. Because
+the pinned install never went through Steam's own bookkeeping, arkmanager would
+otherwise believe the downgraded files are current and never update them, so
+un-pinning throws that bookkeeping away and runs a full `steamcmd` validate
+pass back to the current build. Expect one slow start.
 
 **Steam login:** the current public manifests download fine with the default
 anonymous login. If `steamcmd` reports that the manifest is not available, that
@@ -706,11 +721,19 @@ manifest is not reachable anonymously (this happens for manifests that only
 ever existed on a beta branch) and you need an account that owns ARK, see
 [Configure a Steam login session](#configure-a-steam-login-session).
 
+`download_depot` never learned the manifest request codes Steam introduced in
+2021, so for some older manifests it hands over the current build instead of
+the one you asked for. The entrypoint compares what `steamcmd` reports and
+cached against what you asked for, and refuses to install a mismatch rather
+than quietly putting the broken build back. If that happens, the build is out
+of reach with `steamcmd` and no setting here helps.
+
 **Disk space:** `download_depot` ignores the install directory and always
 stages the full depot below `/home/steam` first, so a pinned install needs
-~25GB there on top of the ~25GB in the server volume. The staging copy is
-removed as soon as it has been moved into place. If you mounted a Steam session
-volume at `/home/steam/Steam`, the staging copy may land there.
+~25GB there on top of the ~25GB in the server volume, and on a normal Docker
+host both are the same disk, so ~50GB. The staging copy is removed as soon as
+it has been moved into place. If you mounted a Steam session volume at
+`/home/steam/Steam`, the staging copy may land there.
 
 ## Cluster and multi-map support
 
@@ -950,7 +973,9 @@ Plan with **at least 8 GB of RAM** (more with mods and larger maps — ARK is
 hungry) and **~25 GB of disk** for the base install, plus headroom for
 staging, backups and mods. Memory can be capped with docker's usual
 `mem_limit` / `deploy.resources` settings, but if the limit is below what the
-map needs the server will simply be OOM-killed.
+map needs the server will simply be OOM-killed. Pinning with
+`TARGET_MANIFEST_ID` needs roughly double the disk during the install, see
+[Pin the server to a Steam manifest](#pin-the-server-to-a-steam-manifest-downgrade).
 
 ### Restore a backup
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ Basic configuration is done with environment variables:
 | ARK_GAME_USER_SETTINGS_INI_FILE | `empty` | Same for `GameUserSettings.ini` |
 | BETA | `empty` | Opt into a Steam beta branch if necessary (e.g. `BETA=preaquatica`) |
 | BETA_ACCESSCODE | `empty` | Access code for the chosen beta branch, if it requires one |
-| TARGET_MANIFEST_ID | `empty` | Pin the server files to one specific Steam manifest of depot `376031`, e.g. to roll back a broken update. Disables all automatic updates while set, see [Pin the server to a Steam manifest](#pin-the-server-to-a-steam-manifest-downgrade) |
-| STEAM_LOGIN | anonymous | Steam account used by `steamcmd` (see [Steam login session](#configure-a-steam-login-session)) |
+| TARGET_MANIFEST_ID | `empty` | Pin the server files to one specific Steam manifest of depot `376031`, e.g. to roll back a broken update. Requires `STEAM_LOGIN` with an account that owns ARK, and disables all automatic updates while set, see [Pin the server to a Steam manifest](#pin-the-server-to-a-steam-manifest-downgrade) |
+| STEAM_LOGIN | anonymous | Steam account used by `steamcmd` (see [Steam login session](#configure-a-steam-login-session)). Anonymous is fine for normal installs, `TARGET_MANIFEST_ID` needs a real account that owns ARK |
 | ARK_SERVER_VOLUME | /app | Path inside the container where the server files are stored |
 | PUID | `empty` | Run the server with a custom UID, e.g. to match the owner of a bind mount on NAS systems. If the server volume's ownership does not match, it is adopted once via a recursive chown, which can take a while |
 | PGID | `empty` | Run the server with a custom GID (see `PUID`) |
@@ -665,7 +665,10 @@ of ARK's content depot (`376031`):
 
 ```yaml
     environment:
+      STEAM_LOGIN: "YOUR_STEAM_USERNAME"
       TARGET_MANIFEST_ID: "6366771435093287465"
+    volumes:
+      - ./Steam:/home/steam/Steam:rw
 ```
 
 This is an escape hatch for broken updates, not an everyday setting. Leave it
@@ -673,6 +676,20 @@ empty (the default) unless a specific build is actually broken for you, and
 remove it again once Wildcard has fixed things. A pinned server misses every
 later fix, and depending on the ARK version, clients may no longer be able to
 join it.
+
+⚠️ **A Steam account that owns ARK is required.** A normal install uses
+`steamcmd`'s `app_update`, which works with the anonymous account. Asking for a
+specific build needs `download_depot`, and Steam does not allow that one
+anonymously:
+
+```
+Depot download failed : missing license for depot (No subscription)
+```
+
+So set `STEAM_LOGIN` to an account that owns ARK: Survival Evolved and mount a
+session, see [Configure a Steam login session](#configure-a-steam-login-session).
+The container refuses to start with a pin and an anonymous login instead of
+downloading for an hour and failing at the end.
 
 **Finding a manifest id:** open
 [depot 376031 on SteamDB](https://steamdb.info/depot/376031/manifests/), find
@@ -722,28 +739,30 @@ otherwise believe the downgraded files are current and never update them, so
 un-pinning throws that bookkeeping away and runs a full `steamcmd` validate
 pass back to the current build. Expect one slow start.
 
-**Steam login:** the current public manifests download fine with the default
-anonymous login. If `steamcmd` reports that the manifest is not available, that
-manifest is not reachable anonymously (this happens for manifests that only
-ever existed on a beta branch) and you need an account that owns ARK, see
-[Configure a Steam login session](#configure-a-steam-login-session).
+**When a manifest cannot be fetched.** Two failures are worth recognising, both
+of them `steamcmd` limitations rather than something to configure away:
 
-`download_depot` never learned the manifest request codes Steam introduced in
-2021, so for some older manifests it hands over the current build instead of
-the one you asked for. The entrypoint compares what `steamcmd` reports and
-cached against what you asked for, and refuses to install a mismatch rather
-than quietly putting the broken build back. If that happens, the build is out
-of reach with `steamcmd` and no setting here helps.
+* `Manifest not available` means the account cannot see that manifest. It
+  happens for manifests that only ever existed on a beta branch.
+* `download_depot` never learned the manifest request codes Steam introduced in
+  2021, so for some older manifests it hands over the current build instead of
+  the one you asked for. The entrypoint compares what `steamcmd` reports and
+  cached against what you asked for and refuses to install a mismatch, rather
+  than quietly putting the broken build back.
+
+In both cases that build is out of reach with `steamcmd`. The container log
+names which one you hit.
 
 **Disk space:** `download_depot` ignores the install directory and always
-stages the full depot below `/home/steam` first, so a pinned install needs
-~25GB there on top of the ~25GB in the server volume. On a normal Docker host
-both are the same disk, so the first pinned install wants ~50GB free and every
-later re-pin ~25GB. The staging copy is removed once it has been moved into
-place, and also when an install gives up, except for a download that was cut
-short, which is kept so a restart can resume it (the error names the directory
-and its size). If you mounted a Steam session volume at `/home/steam/Steam`,
-the staging copy may land there.
+unpacks below `/home/steam/steamcmd` first, so a pinned install needs ~25GB
+there on top of the ~25GB in the server volume. On a normal Docker host both
+are the same disk, so the first pinned install wants ~50GB free and every later
+re-pin ~25GB. Note that `/home/steam/steamcmd` is the container's own
+filesystem, not a volume, so hosts that cap the container writable layer need
+that cap raised. The staging copy is removed once it has been moved into place,
+and also when an install gives up, except for a download that was cut short,
+which is kept so a restart can resume it (the error names the directory and its
+size).
 
 ## Cluster and multi-map support
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Basic configuration is done with environment variables:
 | ARK_GAME_USER_SETTINGS_INI_FILE | `empty` | Same for `GameUserSettings.ini` |
 | BETA | `empty` | Opt into a Steam beta branch if necessary (e.g. `BETA=preaquatica`) |
 | BETA_ACCESSCODE | `empty` | Access code for the chosen beta branch, if it requires one |
+| TARGET_MANIFEST_ID | `empty` | Pin the server files to one specific Steam manifest of depot `376031`, e.g. to roll back a broken update. Disables all automatic updates while set, see [Pin the server to a Steam manifest](#pin-the-server-to-a-steam-manifest-downgrade) |
 | STEAM_LOGIN | anonymous | Steam account used by `steamcmd` (see [Steam login session](#configure-a-steam-login-session)) |
 | ARK_SERVER_VOLUME | /app | Path inside the container where the server files are stored |
 | PUID | `empty` | Run the server with a custom UID, e.g. to match the owner of a bind mount on NAS systems. If the server volume's ownership does not match, it is adopted once via a recursive chown, which can take a while |
@@ -141,7 +142,7 @@ Basic configuration is done with environment variables:
 | UDP_SOCKET_PORT | 7778 | Raw UDP socket port (always game client port +1) |
 | RCON_PORT | 27020 | Exposed RCON port |
 | SERVER_LIST_PORT | 27015 | Exposed server-list (query) port |
-| SKIP_DISK_CHECK | false | Skip the free-disk-space check (~25GB) before the initial server installation |
+| SKIP_DISK_CHECK | false | Skip the free-disk-space check (~25GB) before installing the server files |
 | DISCORD_WEBHOOK_URL | `empty` | Discord webhook to notify on start, stop, crash and restart, see [Discord notifications](#discord-notifications) |
 | DISABLE_HEALTHCHECK | false | Set to `true` to make the [health check](#health-check) always report healthy, for UIs that do not expose `--no-healthcheck` |
 | HEALTHCHECK_REQUIRE_ALL_INSTANCES | false | Report unhealthy as soon as one instance is down, instead of only when all of them are, see [health check](#health-check) |
@@ -655,6 +656,61 @@ and never overwritten. If your server volume was first created with an image
 older than timestamp `1656497302`, edit line 15 of
 `<your-volume>/arkmanager/arkmanager.cfg` and replace it with:
 `steamlogin="${STEAM_LOGIN}"`
+
+### Pin the server to a Steam manifest (downgrade)
+
+Sometimes Wildcard ships a broken build and the only way out is going back to
+the previous one. `TARGET_MANIFEST_ID` pins the server files to one exact build
+of ARK's content depot (`376031`):
+
+```yaml
+    environment:
+      TARGET_MANIFEST_ID: "6366771435093287465"
+```
+
+This is an escape hatch for broken updates, not an everyday setting. Leave it
+empty (the default) unless a specific build is actually broken for you, and
+remove it again once Wildcard has fixed things. A pinned server misses every
+later fix, and depending on the ARK version, clients may no longer be able to
+join it.
+
+**Finding a manifest id:** open
+[depot 376031 on SteamDB](https://steamdb.info/depot/376031/manifests/), find
+the build you want by date, and copy its manifest id (a long number). The
+`public` branch is the one a normal install uses.
+
+**What changes while a pin is set:**
+
+* `arkmanager` has no way to pass a manifest to `steamcmd`, so the install
+  bypasses arkmanager and calls `steamcmd +download_depot` directly.
+* `UPDATE_ON_START` is ignored and arkmanager's own update-before-start is
+  switched off, otherwise the next restart would pull the broken build straight
+  back in. The container log says so on every start.
+* `BETA` is ignored. A manifest id already identifies exactly one build of one
+  branch.
+* Mods are still installed and updated as usual.
+* An explicit `arkmanager update` (for example from one of the
+  [crontab](#add-cronjobs) examples) still updates. Comment those jobs out
+  while you are pinned.
+
+Change `TARGET_MANIFEST_ID` and restart to switch to a different build, or
+remove it to go back to normal updates. Switching from one pin to another
+copies the new build over the old one, it does not delete files the new build
+dropped. That is normally fine, but if a switched server misbehaves, back up
+`<your-volume>/server/ShooterGame/Saved`, delete `<your-volume>/server` and let
+it install again.
+
+**Steam login:** the current public manifests download fine with the default
+anonymous login. If `steamcmd` reports that the manifest is not available, that
+manifest is not reachable anonymously (this happens for manifests that only
+ever existed on a beta branch) and you need an account that owns ARK, see
+[Configure a Steam login session](#configure-a-steam-login-session).
+
+**Disk space:** `download_depot` ignores the install directory and always
+stages the full depot below `/home/steam` first, so a pinned install needs
+~25GB there on top of the ~25GB in the server volume. The staging copy is
+removed as soon as it has been moved into place. If you mounted a Steam session
+volume at `/home/steam/Steam`, the staging copy may land there.
 
 ## Cluster and multi-map support
 

--- a/README.md
+++ b/README.md
@@ -537,12 +537,18 @@ vim "${HOME}/ark-server/crontab"
 Add your desired cronjobs with valid syntax (they run as the `steam` user):
 
 ```bash
-0 4 * * * arkmanager update @all --warn --update-mods >> /app/log/crontab.log 2>&1
+0 4 * * * [ -z "${TARGET_MANIFEST_ID}" ] && arkmanager update @all --warn --update-mods >> /app/log/crontab.log 2>&1
 0 0 * * * arkmanager backup @all >> /app/log/crontab.log 2>&1
 ```
 
 (`@all` targets every instance — identical to `@main` on a single-map server
 and required on [multi-map servers](#cluster-and-multi-map-support).)
+
+The `[ -z "${TARGET_MANIFEST_ID}" ]` guard keeps the job away from a server
+pinned with [`TARGET_MANIFEST_ID`](#pin-the-server-to-a-steam-manifest-downgrade).
+arkmanager only ever updates to the newest build, so without the guard the job
+undoes the pin and puts the build you are escaping back. Cron jobs read the
+same exported environment as the server, so the variable is there.
 
 The container environment is exported to `/app/environment` on every start and
 loaded into each job via the crontab's `BASH_ENV` header, so cron jobs see the
@@ -580,9 +586,9 @@ and skip the rest of this section.
 
 ```bash
 # every hour: check for a new build and pull it into staging, nothing stops
-0 * * * * arkmanager update @all --downloadonly --update-mods >> /app/log/crontab.log 2>&1
+0 * * * * [ -z "${TARGET_MANIFEST_ID}" ] && arkmanager update @all --downloadonly --update-mods >> /app/log/crontab.log 2>&1
 # 6am: apply it, but only if something new really is staged
-0 6 * * * cmp -s /app/server/steamapps/appmanifest_376030.acf /app/staging/steamapps/appmanifest_376030.acf || arkmanager update @all --no-download --update-mods --warn >> /app/log/crontab.log 2>&1
+0 6 * * * [ -z "${TARGET_MANIFEST_ID}" ] && ! cmp -s /app/server/steamapps/appmanifest_376030.acf /app/staging/steamapps/appmanifest_376030.acf && arkmanager update @all --no-download --update-mods --warn >> /app/log/crontab.log 2>&1
 ```
 
 That `cmp` guard is not decoration. The apply job never compares the staged
@@ -597,6 +603,11 @@ at all, which counts as different. Downloading hourly instead of once keeps
 staging fresh enough that the 6am window usually has something to apply. And if
 a newer build appears between the last download and the apply, you get the one
 you staged and the next cycle catches up.
+
+The `cmp` guard says nothing about a pinned server, which is why both jobs
+carry the `TARGET_MANIFEST_ID` guard as well. A pinned install has no
+`appmanifest_376030.acf` at all, so the comparison differs from the first
+staged download onwards and the apply job would swap in unpinned binaries.
 
 About the countdown. `--warn` counts down `arkwarnminutes` from
 `arkmanager.cfg` (60 here), but `arkprecisewarn` is `false`, so with nobody
@@ -708,21 +719,35 @@ the one that broke.
 * Updates are off. `UPDATE_ON_START` is ignored, and so is arkmanager's own
   update-before-start (`arkmanager start`/`restart` from a cron job). The
   container log says so on every start.
-* Mods are frozen too. A mod built for the current build usually does not load
-  on an older one, so freezing them next to the binaries is the point.
+* **Mods are not pinned, and cannot be.** The Workshop only ever serves a mod's
+  current version, and there is no manifest to ask for. So a pinned server with
+  `GAME_MOD_IDS` or `SERVER_MAP_MOD_ID` installs mods built against the current
+  server build, next to older binaries. Mods that were already installed are
+  left alone (the install loop skips them), which is the closest thing to
+  freezing you get. If a mod refuses to load on the pinned build, there is no
+  setting here that helps.
 * `BETA` is ignored. A manifest id already identifies exactly one build of one
   branch.
-* An explicit `arkmanager update` (for example from one of the
-  [crontab](#add-cronjobs) examples) still updates and undoes the pin. Comment
-  those jobs out while you are pinned. If one runs anyway, the next start
-  notices, says so, and re-applies the pin.
+* An explicit `arkmanager update` still updates and undoes the pin. Every
+  update job in the shipped [crontab](#add-cronjobs) examples is guarded with
+  `[ -z "${TARGET_MANIFEST_ID}" ]` for exactly this reason. If you wrote your
+  own job, add the same guard. A crontab created by an older version of this
+  image keeps its unguarded jobs, the template is only copied once, so check
+  `<your-volume>/crontab` before you pin.
 
-  What that check actually is: the image records the Steam build id and a
-  checksum of `ShooterGameServer` when it pins, and compares both on every
-  start. So it catches anything that replaces the server binary or Steam's
-  records. It does not checksum the other ~22GB, so a change limited to game
-  content with the binary left alone goes unnoticed. It is a tripwire for the
-  update paths that exist in this image, not a full integrity check.
+  If an update runs anyway, the next container start notices and re-applies the
+  pin. Two things to be clear about: the check only runs at startup, so an
+  unpinned server can serve players for as long as it takes you to restart it,
+  and re-applying the pin means downloading the full ~22GB again, it is not a
+  cheap repair.
+
+  What the check actually is: the image records the Steam build id and a
+  checksum of `ShooterGameServer` at the moment it pins, and compares both on
+  every start. Those two values say "nothing has replaced the server since we
+  pinned it". They do not identify which build is on disk. Anything that leaves
+  the executable byte for byte identical is invisible, including changes
+  confined to the other ~22GB of content. It is a tripwire for the update paths
+  this image has, not an integrity check.
 * A backup is taken before the server binaries are swapped, unless you set
   `PRE_UPDATE_BACKUP=false`. If the backup fails, the swap is refused: an older
   build rewrites the saves it loads on the first autosave.
@@ -738,6 +763,12 @@ the pinned install never went through Steam's own bookkeeping, arkmanager would
 otherwise believe the downgraded files are current and never update them, so
 un-pinning throws that bookkeeping away and runs a full `steamcmd` validate
 pass back to the current build. Expect one slow start.
+
+Careful: an empty `TARGET_MANIFEST_ID` is all it takes, so starting the
+container without your env file un-pins it and walks the server straight back
+to the build you were escaping. A backup is taken first (unless
+`PRE_UPDATE_BACKUP=false`) and the log says what is happening, but nothing asks
+you to confirm.
 
 **When a manifest cannot be fetched.** Two failures are worth recognising, both
 of them `steamcmd` limitations rather than something to configure away:

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+ARK_APP_ID="376030"
+ARK_CONTENT_DEPOT_ID="376031"
+# shared Steamworks redistributable depot, owned by app 1007
+ARK_REDIST_DEPOT_ID="1006"
+MANIFEST_PIN_FILE="${ARK_SERVER_VOLUME}/server/.ark_manifest_pin"
+PINNED_INSTALL_LOG="${ARK_SERVER_VOLUME}/log/steamcmd-pinned-install.log"
+
 function may_update() {
   if [[ -n "${TARGET_MANIFEST_ID}" ]]; then
     echo "Not updating: this server is pinned to manifest ${TARGET_MANIFEST_ID} (\$TARGET_MANIFEST_ID)."
@@ -242,6 +249,20 @@ function apply_ini_file() {
   echo "...applied ${source_file} to ${destination} for instance ${instance}"
 }
 
+function read_pin_field() {
+  local -r FIELD="${1}"
+
+  [[ -f "${MANIFEST_PIN_FILE}" ]] || return 0
+  sed -n "s/^${FIELD}=//p" "${MANIFEST_PIN_FILE}" | tail -n1
+}
+
+function installed_steam_buildid() {
+  local -r ACF="${ARK_SERVER_VOLUME}/server/steamapps/appmanifest_${ARK_APP_ID}.acf"
+
+  [[ -f "${ACF}" ]] || return 0
+  sed -n 's/.*"buildid"[^0-9]*"\([0-9]*\)".*/\1/p' "${ACF}" | head -n1
+}
+
 function needs_install() {
   local SERVER_DIR="${ARK_SERVER_VOLUME}/server"
   local SERVER_EXEC="${SERVER_DIR}/ShooterGame/Binaries/Linux/ShooterGameServer"
@@ -250,10 +271,30 @@ function needs_install() {
     return 0
   fi
 
-  if [[ -n "${TARGET_MANIFEST_ID}" ]] &&
-     [[ "$(cat "${MANIFEST_PIN_FILE}" 2>/dev/null)" != "${TARGET_MANIFEST_ID}" ]]; then
-    echo "Installed files were not pinned to manifest ${TARGET_MANIFEST_ID} ..."
-    return 0
+  if [[ -n "${TARGET_MANIFEST_ID}" ]]; then
+    if [[ "$(read_pin_field manifest)" != "${TARGET_MANIFEST_ID}" ]]; then
+      echo "Installed files are not pinned to manifest ${TARGET_MANIFEST_ID} ..."
+      return 0
+    fi
+
+    # arkmanager rewrites the appmanifest every time it runs app_update, e.g.
+    # from a cron 'arkmanager update' - a changed build id is the only trace
+    # left when something replaced the pinned binaries behind our back
+    if [[ "$(read_pin_field buildid)" != "$(installed_steam_buildid)" ]]; then
+      echo "The Steam build id changed since this server was pinned - something updated it, re-applying the pin ..."
+      return 0
+    fi
+
+    # download_depot writes no appmanifest and the ARK depot ships no
+    # version.txt, so the pin file plus the unpacked depot is the only proof
+    # that a pinned install ever completed
+    if [ ! -s "${SERVER_EXEC}" ] || [ ! -d "${SERVER_DIR}/Engine" ]; then
+      echo "The pinned server files are not complete ..."
+      return 0
+    fi
+
+    echo "Already installed (pinned to manifest ${TARGET_MANIFEST_ID})."
+    return 1
   fi
 
   # Backwards compatibility - but only trust version.txt if the server
@@ -265,7 +306,7 @@ function needs_install() {
   fi
 
   local INSTALLED_FILES=(
-    "${SERVER_DIR}/steamapps/appmanifest_376030.acf"
+    "${SERVER_DIR}/steamapps/appmanifest_${ARK_APP_ID}.acf"
     "${SERVER_EXEC}"
   )
   for FILE in "${INSTALLED_FILES[@]}"; do
@@ -279,11 +320,16 @@ function needs_install() {
   return 1
 }
 
+function filesystem_of() {
+  df -P "${1}" 2>/dev/null | awk 'NR==2 {print $1}'
+}
+
 function assert_free_disk_space_on() {
-  # a fresh ARK install needs roughly 25GB (plus staging/backup headroom)
-  local REQUIRED_MB="25000"
-  local TARGET="${1}"
+  local -r TARGET="${1}"
+  local -r REQUIRED_MB="${2}"
   local AVAILABLE_MB
+
+  (( REQUIRED_MB > 0 )) || return 0
 
   AVAILABLE_MB="$(df -Pm "${TARGET}" | awk 'NR==2 {print $4}')"
   if [[ -n "${AVAILABLE_MB}" ]] && (( AVAILABLE_MB < REQUIRED_MB )); then
@@ -295,86 +341,205 @@ function assert_free_disk_space_on() {
 }
 
 function assert_free_disk_space() {
+  # a fresh ARK install needs roughly 25GB (plus staging/backup headroom)
+  local -r REQUIRED_MB="25000"
+  local -a TARGETS=() AMOUNTS=()
+  local CANDIDATE NEEDED SEEN_EARLIER
+  local -i I J
+
   if [[ "${SKIP_DISK_CHECK}" == "true" ]]; then
     return
   fi
-
-  # steamcmd's download_depot ignores force_install_dir and always stages the
-  # full depot below its own home first, so a pinned install needs the space
-  # twice - and it needs it again for every re-pin, not just the first install
-  [[ -z "${TARGET_MANIFEST_ID}" ]] || assert_free_disk_space_on "${STEAM_HOME}"
 
   # repair installs already have most content on disk and steamcmd validate
   # only fetches what is missing - the full-size gate is for fresh installs.
   # Content is only ever created by the install path (not the config-symlink
   # healing above), so it reliably marks a previous install attempt.
-  if [[ -d "${ARK_SERVER_VOLUME}/server/ShooterGame/Content" ]]; then
-    return
+  if [[ ! -d "${ARK_SERVER_VOLUME}/server/ShooterGame/Content" ]]; then
+    TARGETS+=("${ARK_SERVER_VOLUME}")
+    AMOUNTS+=("${REQUIRED_MB}")
   fi
 
-  assert_free_disk_space_on "${ARK_SERVER_VOLUME}"
+  # download_depot ignores force_install_dir and always stages the full depot
+  # below steamcmd's home first, on every pinned install. Which directory it
+  # picks there is not fixed, and a mounted Steam session volume can put one
+  # of them on a different filesystem, so require the space on both.
+  if [[ -n "${TARGET_MANIFEST_ID}" ]]; then
+    for CANDIDATE in "${STEAM_HOME}" "${STEAM_HOME}/Steam"; do
+      [[ -d "${CANDIDATE}" ]] || continue
+      TARGETS+=("${CANDIDATE}")
+      AMOUNTS+=("${REQUIRED_MB}")
+    done
+  fi
+
+  # on a default Docker host all of these live on the same device, where only
+  # the sum of the requirements actually fits
+  for (( I = 0; I < ${#TARGETS[@]}; I++ )); do
+    NEEDED=0
+    SEEN_EARLIER=""
+    for (( J = 0; J < ${#TARGETS[@]}; J++ )); do
+      [[ "$(filesystem_of "${TARGETS[J]}")" == "$(filesystem_of "${TARGETS[I]}")" ]] || continue
+      if (( J < I )); then
+        SEEN_EARLIER="yes"
+      fi
+      NEEDED=$(( NEEDED + AMOUNTS[J] ))
+    done
+    [[ -z "${SEEN_EARLIER}" ]] || continue
+    assert_free_disk_space_on "${TARGETS[I]}" "${NEEDED}"
+  done
 }
 
 function find_downloaded_depot() {
-  local -r APP_ID="${1}"
-  local -r DEPOT_ID="${2}"
+  local -r DEPOT_ID="${1}"
 
-  # the depth limit keeps find out of the ~22GB of depot content it would
-  # otherwise walk through
+  # match on the depot id alone: depot 1006 belongs to app 1007, so steamcmd
+  # files it under a different app directory than the one we asked for. The
+  # depth limit keeps find out of the ~22GB of depot content below the match.
   find "${STEAM_HOME}" -maxdepth 6 -type d \
-    -path "*/steamapps/content/app_${APP_ID}/depot_${DEPOT_ID}" -print -quit 2>/dev/null
+    -path "*/content/app_*/depot_${DEPOT_ID}" -print -quit 2>/dev/null
+}
+
+function find_cached_manifest() {
+  local -r DEPOT_ID="${1}"
+  local -r MANIFEST_ID="${2}"
+
+  find "${STEAM_HOME}" -maxdepth 5 -type f \
+    -name "${DEPOT_ID}_${MANIFEST_ID}.manifest" -print -quit 2>/dev/null
+}
+
+function steamcmd_download_depot() {
+  local -r DEPOT_ID="${1}"
+  local -r MANIFEST_ID="${2}"
+  local -a DEPOT_ARGS=(+download_depot "${ARK_APP_ID}" "${DEPOT_ID}")
+
+  # steamcmd keeps the manifest it really fetched in depotcache as
+  # <depotid>_<manifestid>.manifest; dropping a stale copy first turns its
+  # presence afterwards into proof that this run fetched that exact manifest
+  if [[ -n "${MANIFEST_ID}" ]]; then
+    DEPOT_ARGS+=("${MANIFEST_ID}")
+    rm -f "$(find_cached_manifest "${DEPOT_ID}" "${MANIFEST_ID}")" 2>/dev/null || true
+  fi
+
+  "${STEAM_HOME}/steamcmd/steamcmd.sh" \
+    +@NoPromptForPassword 1 \
+    +login "${STEAM_LOGIN:-anonymous}" \
+    "${DEPOT_ARGS[@]}" \
+    +quit 2>&1 | tee -a "${PINNED_INSTALL_LOG}" || true
+}
+
+# echoes the directory the depot was unpacked into, or fails with
+# 1 = no completed download, 2 = a different manifest than the one asked for
+function verified_depot_path() {
+  local -r DEPOT_ID="${1}"
+  local -r EXPECTED_MANIFEST="${2}"
+  local LINE DEPOT_PATH REPORTED_MANIFEST CROSS_CHECKED=""
+
+  # steamcmd's exit status is useless (it reports success for downloads that
+  # never happened), this line is its only completeness signal
+  LINE="$(grep -i 'depot download complete' "${PINNED_INSTALL_LOG}" | grep -F "depot_${DEPOT_ID}" | tail -n1)"
+  [[ -n "${LINE}" ]] || return 1
+
+  DEPOT_PATH="$(sed -n 's/.*"\([^"]*\)".*/\1/p' <<< "${LINE}")"
+  [[ -d "${DEPOT_PATH}" ]] || DEPOT_PATH="$(find_downloaded_depot "${DEPOT_ID}")"
+  [[ -d "${DEPOT_PATH}" ]] || return 1
+
+  if [[ -n "${EXPECTED_MANIFEST}" ]]; then
+    REPORTED_MANIFEST="$(sed -n 's/.*manifest \([0-9][0-9]*\).*/\1/p' <<< "${LINE}")"
+    if [[ -n "${REPORTED_MANIFEST}" ]]; then
+      [[ "${REPORTED_MANIFEST}" == "${EXPECTED_MANIFEST}" ]] || return 2
+      CROSS_CHECKED="yes"
+    fi
+
+    if [[ -n "$(find "${STEAM_HOME}" -maxdepth 4 -type d -name depotcache -print -quit 2>/dev/null)" ]]; then
+      [[ -n "$(find_cached_manifest "${DEPOT_ID}" "${EXPECTED_MANIFEST}")" ]] || return 2
+      CROSS_CHECKED="yes"
+    fi
+
+    [[ -n "${CROSS_CHECKED}" ]] ||
+      echo "WARNING: could not confirm which manifest steamcmd delivered for depot ${DEPOT_ID}" >&2
+  fi
+
+  echo "${DEPOT_PATH}"
 }
 
 function install_depot_files() {
   local -r DEPOT_DIR="${1}"
 
   echo "...moving ${DEPOT_DIR} into ${ARK_SERVER_VOLUME}/server"
-  cp -a "${DEPOT_DIR}/." "${ARK_SERVER_VOLUME}/server/"
+  if ! cp -a "${DEPOT_DIR}/." "${ARK_SERVER_VOLUME}/server/"; then
+    echo "ERROR: could not copy ${DEPOT_DIR} into ${ARK_SERVER_VOLUME}/server - out of disk space?"
+    echo "       Removing the downloaded depot so the next attempt has room again."
+    rm -rf "${DEPOT_DIR}"
+    exit 1
+  fi
   # steamcmd never cleans up its download directory, and leaving it behind
   # would keep a second full copy of the server files on disk
   rm -rf "${DEPOT_DIR}"
 }
 
-function install_pinned_manifest() {
-  local -r APP_ID="376030"
-  local -r CONTENT_DEPOT_ID="376031"
-  local -r REDIST_DEPOT_ID="1006"
-  local CONTENT_DIR REDIST_DIR
+function backup_before_binary_swap() {
+  local -r SAVED_DIR="${ARK_SERVER_VOLUME}/server/ShooterGame/Saved"
 
-  echo "Installing app ${APP_ID} pinned to manifest ${TARGET_MANIFEST_ID}..."
+  [[ "${PRE_UPDATE_BACKUP}" == "true" ]] || return 0
+  [[ -n "$(find "${SAVED_DIR}" -mindepth 1 -maxdepth 2 -name '*.ark' -print -quit 2>/dev/null)" ]] || return 0
+
+  echo "Creating a backup before swapping the server binaries (\$PRE_UPDATE_BACKUP is 'true')..."
+  if ! ${ARKMANAGER} backup @main; then
+    echo "ERROR: the backup failed, refusing to swap the server binaries."
+    echo "       A pin usually moves the server to an older build, and an older build rewrites"
+    echo "       the saves it loads on the first autosave - going ahead risks the world."
+    echo "       Fix the backup, or set PRE_UPDATE_BACKUP=false to swap without one."
+    exit 1
+  fi
+}
+
+function install_pinned_manifest() {
+  local CONTENT_DIR REDIST_DIR
+  local -i RESULT=0
+
+  echo "Installing app ${ARK_APP_ID} pinned to manifest ${TARGET_MANIFEST_ID}..."
   echo "arkmanager cannot pass a manifest to steamcmd, so this bypasses it and calls steamcmd directly."
 
-  # steamcmd reports success for downloads that never happened, so the depot
-  # directories below decide whether this worked, not the exit status
-  "${STEAM_HOME}/steamcmd/steamcmd.sh" \
-    +@NoPromptForPassword 1 \
-    +login "${STEAM_LOGIN:-anonymous}" \
-    +download_depot "${APP_ID}" "${REDIST_DEPOT_ID}" \
-    +download_depot "${APP_ID}" "${CONTENT_DEPOT_ID}" "${TARGET_MANIFEST_ID}" \
-    +quit || true
+  : > "${PINNED_INSTALL_LOG}"
+  steamcmd_download_depot "${ARK_REDIST_DEPOT_ID}" ""
+  steamcmd_download_depot "${ARK_CONTENT_DEPOT_ID}" "${TARGET_MANIFEST_ID}"
 
-  CONTENT_DIR="$(find_downloaded_depot "${APP_ID}" "${CONTENT_DEPOT_ID}")"
-  if [[ -z "${CONTENT_DIR}" ]]; then
-    echo "ERROR: steamcmd did not download depot ${CONTENT_DEPOT_ID} at manifest ${TARGET_MANIFEST_ID}."
-    echo "       Check its output above and verify the manifest id on"
-    echo "       https://steamdb.info/depot/${CONTENT_DEPOT_ID}/manifests/"
-    echo "       'Manifest not available' means this account cannot see that manifest - set"
-    echo "       STEAM_LOGIN to an account that owns ARK and mount a Steam session (see the README)."
+  CONTENT_DIR="$(verified_depot_path "${ARK_CONTENT_DEPOT_ID}" "${TARGET_MANIFEST_ID}")" || RESULT=$?
+  if (( RESULT == 2 )); then
+    echo "ERROR: steamcmd did not deliver manifest ${TARGET_MANIFEST_ID} of depot ${ARK_CONTENT_DEPOT_ID}."
+    echo "       download_depot was never taught the manifest request codes Steam introduced in 2021,"
+    echo "       so for some older manifests it quietly downloads the current build instead."
+    echo "       Refusing to install that - it would put the build you are escaping back on disk."
+    exit 1
+  fi
+  if (( RESULT != 0 )); then
+    echo "ERROR: steamcmd did not finish downloading depot ${ARK_CONTENT_DEPOT_ID} at manifest ${TARGET_MANIFEST_ID}."
+    echo "       Its full output is in ${PINNED_INSTALL_LOG}."
+    echo "       Verify the manifest id on https://steamdb.info/depot/${ARK_CONTENT_DEPOT_ID}/manifests/"
+    echo "       'Manifest not available' means this account cannot see that manifest - set STEAM_LOGIN"
+    echo "       to an account that owns ARK and mount a Steam session (see the README)."
+    echo "       The partial download was kept so a restart can resume it."
     exit 1
   fi
 
-  # the ARK server binary loads steamclient.so from linux64/, which lives in
-  # the shared Steamworks redistributable depot rather than in the game depot
-  REDIST_DIR="$(find_downloaded_depot "${APP_ID}" "${REDIST_DEPOT_ID}")"
-  if [[ -n "${REDIST_DIR}" ]]; then
-    install_depot_files "${REDIST_DIR}"
-  else
-    echo "WARNING: depot ${REDIST_DEPOT_ID} (Steamworks redistributables) was not downloaded, continuing..."
-  fi
+  backup_before_binary_swap
 
   install_depot_files "${CONTENT_DIR}"
+  # download_depot hands the files over without the executable bit, unlike the
+  # app_update path arkmanager uses
+  chmod +x "${ARK_SERVER_VOLUME}/server/ShooterGame/Binaries/Linux/ShooterGameServer"
 
-  echo "${TARGET_MANIFEST_ID}" > "${MANIFEST_PIN_FILE}"
+  # the ARK server binary loads steamclient.so from linux64/, which lives in
+  # the shared Steamworks redistributable depot rather than in the game depot
+  RESULT=0
+  REDIST_DIR="$(verified_depot_path "${ARK_REDIST_DEPOT_ID}" "")" || RESULT=$?
+  if (( RESULT == 0 )); then
+    install_depot_files "${REDIST_DIR}"
+  else
+    echo "WARNING: depot ${ARK_REDIST_DEPOT_ID} (Steamworks redistributables) did not download, continuing..."
+  fi
+
+  printf 'manifest=%s\nbuildid=%s\n' "${TARGET_MANIFEST_ID}" "$(installed_steam_buildid)" > "${MANIFEST_PIN_FILE}"
 }
 
 function add_cluster_to_arkmanager_cfg() {
@@ -765,17 +930,17 @@ done
 # restarts on failure would repeat that on every cycle just to hit the same typo
 assert_ini_files_are_usable
 
-MANIFEST_PIN_FILE="${ARK_SERVER_VOLUME}/server/.target_manifest_id"
 if [[ -n "${TARGET_MANIFEST_ID}" ]]; then
   if [[ ! "${TARGET_MANIFEST_ID}" =~ ^[0-9]+$ ]]; then
     echo "ERROR: TARGET_MANIFEST_ID='${TARGET_MANIFEST_ID}' must be a plain numeric Steam manifest id."
-    echo "       Look it up on https://steamdb.info/depot/376031/manifests/"
+    echo "       Look it up on https://steamdb.info/depot/${ARK_CONTENT_DEPOT_ID}/manifests/"
     exit 1
   fi
 
-  # arkmanager only ever updates to the newest build, and it starts an update
-  # on its own when arkAutoUpdateOnStart is true - the config binds that to
-  # UPDATE_ON_START, and cron jobs read the same exported environment
+  # arkmanager only ever updates to the newest build. 'arkmanager run' does not
+  # update on its own, but 'arkmanager start'/'restart' do when
+  # arkAutoUpdateOnStart is true, and the config binds that to UPDATE_ON_START -
+  # cron jobs read the same exported environment
   if [[ "${UPDATE_ON_START}" == "true" ]]; then
     echo "WARNING: UPDATE_ON_START is ignored while TARGET_MANIFEST_ID pins this server to a manifest"
   fi
@@ -866,12 +1031,18 @@ fi
 heal_config_symlinks
 
 if [[ -z "${TARGET_MANIFEST_ID}" ]] && [[ -f "${MANIFEST_PIN_FILE}" ]]; then
-  echo "TARGET_MANIFEST_ID is no longer set, dropping the manifest pin - updates will move this server to the latest build again."
-  rm -f "${MANIFEST_PIN_FILE}"
+  echo "TARGET_MANIFEST_ID is no longer set, removing the manifest pin."
+  echo "The pinned install bypassed steamcmd's bookkeeping, so arkmanager cannot tell which build is"
+  echo "on disk and would happily call it up to date. Dropping that bookkeeping forces a full"
+  echo "steamcmd validate pass back to the current build, which takes a while but is the only"
+  echo "way back to a server arkmanager can keep updated."
+  rm -f "${MANIFEST_PIN_FILE}" \
+        "${ARK_SERVER_VOLUME}/server/steamapps/appmanifest_${ARK_APP_ID}.acf" \
+        "${ARK_SERVER_VOLUME}/server/version.txt"
 fi
 
 if needs_install; then
-  echo "No game files found. Installing..."
+  echo "Installing the ARK server files..."
 
   assert_free_disk_space
 

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
 function may_update() {
+  if [[ -n "${TARGET_MANIFEST_ID}" ]]; then
+    echo "Not updating: this server is pinned to manifest ${TARGET_MANIFEST_ID} (\$TARGET_MANIFEST_ID)."
+    return
+  fi
+
   if [[ "${UPDATE_ON_START}" != "true" ]]; then
     [[ "${VALIDATE_ON_START}" != "true" ]] ||
       echo "WARNING: VALIDATE_ON_START has no effect because UPDATE_ON_START is not 'true' - skipping validation"
@@ -245,6 +250,12 @@ function needs_install() {
     return 0
   fi
 
+  if [[ -n "${TARGET_MANIFEST_ID}" ]] &&
+     [[ "$(cat "${MANIFEST_PIN_FILE}" 2>/dev/null)" != "${TARGET_MANIFEST_ID}" ]]; then
+    echo "Installed files were not pinned to manifest ${TARGET_MANIFEST_ID} ..."
+    return 0
+  fi
+
   # Backwards compatibility - but only trust version.txt if the server
   # executable actually exists, otherwise trigger a repair install
   local VERSION_FILE="${SERVER_DIR}/version.txt"
@@ -268,14 +279,30 @@ function needs_install() {
   return 1
 }
 
-function assert_free_disk_space() {
+function assert_free_disk_space_on() {
   # a fresh ARK install needs roughly 25GB (plus staging/backup headroom)
   local REQUIRED_MB="25000"
+  local TARGET="${1}"
   local AVAILABLE_MB
 
+  AVAILABLE_MB="$(df -Pm "${TARGET}" | awk 'NR==2 {print $4}')"
+  if [[ -n "${AVAILABLE_MB}" ]] && (( AVAILABLE_MB < REQUIRED_MB )); then
+    echo "ERROR: Not enough free disk space on ${TARGET}:"
+    echo "       ${AVAILABLE_MB}MB available, ~${REQUIRED_MB}MB required for the ARK server files."
+    echo "       Free up disk space, or set SKIP_DISK_CHECK=true to install anyway."
+    exit 1
+  fi
+}
+
+function assert_free_disk_space() {
   if [[ "${SKIP_DISK_CHECK}" == "true" ]]; then
     return
   fi
+
+  # steamcmd's download_depot ignores force_install_dir and always stages the
+  # full depot below its own home first, so a pinned install needs the space
+  # twice - and it needs it again for every re-pin, not just the first install
+  [[ -z "${TARGET_MANIFEST_ID}" ]] || assert_free_disk_space_on "${STEAM_HOME}"
 
   # repair installs already have most content on disk and steamcmd validate
   # only fetches what is missing - the full-size gate is for fresh installs.
@@ -285,13 +312,69 @@ function assert_free_disk_space() {
     return
   fi
 
-  AVAILABLE_MB="$(df -Pm "${ARK_SERVER_VOLUME}" | awk 'NR==2 {print $4}')"
-  if [[ -n "${AVAILABLE_MB}" ]] && (( AVAILABLE_MB < REQUIRED_MB )); then
-    echo "ERROR: Not enough free disk space on ${ARK_SERVER_VOLUME}:"
-    echo "       ${AVAILABLE_MB}MB available, ~${REQUIRED_MB}MB required for the ARK server files."
-    echo "       Free up disk space, or set SKIP_DISK_CHECK=true to install anyway."
+  assert_free_disk_space_on "${ARK_SERVER_VOLUME}"
+}
+
+function find_downloaded_depot() {
+  local -r APP_ID="${1}"
+  local -r DEPOT_ID="${2}"
+
+  # the depth limit keeps find out of the ~22GB of depot content it would
+  # otherwise walk through
+  find "${STEAM_HOME}" -maxdepth 6 -type d \
+    -path "*/steamapps/content/app_${APP_ID}/depot_${DEPOT_ID}" -print -quit 2>/dev/null
+}
+
+function install_depot_files() {
+  local -r DEPOT_DIR="${1}"
+
+  echo "...moving ${DEPOT_DIR} into ${ARK_SERVER_VOLUME}/server"
+  cp -a "${DEPOT_DIR}/." "${ARK_SERVER_VOLUME}/server/"
+  # steamcmd never cleans up its download directory, and leaving it behind
+  # would keep a second full copy of the server files on disk
+  rm -rf "${DEPOT_DIR}"
+}
+
+function install_pinned_manifest() {
+  local -r APP_ID="376030"
+  local -r CONTENT_DEPOT_ID="376031"
+  local -r REDIST_DEPOT_ID="1006"
+  local CONTENT_DIR REDIST_DIR
+
+  echo "Installing app ${APP_ID} pinned to manifest ${TARGET_MANIFEST_ID}..."
+  echo "arkmanager cannot pass a manifest to steamcmd, so this bypasses it and calls steamcmd directly."
+
+  # steamcmd reports success for downloads that never happened, so the depot
+  # directories below decide whether this worked, not the exit status
+  "${STEAM_HOME}/steamcmd/steamcmd.sh" \
+    +@NoPromptForPassword 1 \
+    +login "${STEAM_LOGIN:-anonymous}" \
+    +download_depot "${APP_ID}" "${REDIST_DEPOT_ID}" \
+    +download_depot "${APP_ID}" "${CONTENT_DEPOT_ID}" "${TARGET_MANIFEST_ID}" \
+    +quit || true
+
+  CONTENT_DIR="$(find_downloaded_depot "${APP_ID}" "${CONTENT_DEPOT_ID}")"
+  if [[ -z "${CONTENT_DIR}" ]]; then
+    echo "ERROR: steamcmd did not download depot ${CONTENT_DEPOT_ID} at manifest ${TARGET_MANIFEST_ID}."
+    echo "       Check its output above and verify the manifest id on"
+    echo "       https://steamdb.info/depot/${CONTENT_DEPOT_ID}/manifests/"
+    echo "       'Manifest not available' means this account cannot see that manifest - set"
+    echo "       STEAM_LOGIN to an account that owns ARK and mount a Steam session (see the README)."
     exit 1
   fi
+
+  # the ARK server binary loads steamclient.so from linux64/, which lives in
+  # the shared Steamworks redistributable depot rather than in the game depot
+  REDIST_DIR="$(find_downloaded_depot "${APP_ID}" "${REDIST_DEPOT_ID}")"
+  if [[ -n "${REDIST_DIR}" ]]; then
+    install_depot_files "${REDIST_DIR}"
+  else
+    echo "WARNING: depot ${REDIST_DEPOT_ID} (Steamworks redistributables) was not downloaded, continuing..."
+  fi
+
+  install_depot_files "${CONTENT_DIR}"
+
+  echo "${TARGET_MANIFEST_ID}" > "${MANIFEST_PIN_FILE}"
 }
 
 function add_cluster_to_arkmanager_cfg() {
@@ -682,6 +765,27 @@ done
 # restarts on failure would repeat that on every cycle just to hit the same typo
 assert_ini_files_are_usable
 
+MANIFEST_PIN_FILE="${ARK_SERVER_VOLUME}/server/.target_manifest_id"
+if [[ -n "${TARGET_MANIFEST_ID}" ]]; then
+  if [[ ! "${TARGET_MANIFEST_ID}" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: TARGET_MANIFEST_ID='${TARGET_MANIFEST_ID}' must be a plain numeric Steam manifest id."
+    echo "       Look it up on https://steamdb.info/depot/376031/manifests/"
+    exit 1
+  fi
+
+  # arkmanager only ever updates to the newest build, and it starts an update
+  # on its own when arkAutoUpdateOnStart is true - the config binds that to
+  # UPDATE_ON_START, and cron jobs read the same exported environment
+  if [[ "${UPDATE_ON_START}" == "true" ]]; then
+    echo "WARNING: UPDATE_ON_START is ignored while TARGET_MANIFEST_ID pins this server to a manifest"
+  fi
+  UPDATE_ON_START="false"
+
+  if [[ -n "${BETA}" ]]; then
+    echo "WARNING: BETA has no effect while TARGET_MANIFEST_ID is set - a manifest id already identifies one build of one branch"
+  fi
+fi
+
 args=("$@")
 if [[ "${ENABLE_CROSSPLAY}" == "true" ]]; then
   args=('--arkopt,-crossplay' "${args[@]}")
@@ -706,6 +810,9 @@ echo "# RUNNING AS USER '${STEAM_USER}' - '$(id -u)'"
 echo "# ARGS: ${args[*]}"
 if [ -n "${BETA}" ]; then
   echo "# BETA: ${BETA}"
+fi
+if [ -n "${TARGET_MANIFEST_ID}" ]; then
+  echo "# TARGET_MANIFEST_ID: ${TARGET_MANIFEST_ID}"
 fi
 echo "_______________________________________"
 
@@ -758,6 +865,11 @@ fi
 
 heal_config_symlinks
 
+if [[ -z "${TARGET_MANIFEST_ID}" ]] && [[ -f "${MANIFEST_PIN_FILE}" ]]; then
+  echo "TARGET_MANIFEST_ID is no longer set, dropping the manifest pin - updates will move this server to the latest build again."
+  rm -f "${MANIFEST_PIN_FILE}"
+fi
+
 if needs_install; then
   echo "No game files found. Installing..."
 
@@ -771,7 +883,9 @@ if needs_install; then
   touch "${ARK_SERVER_VOLUME}/server/ShooterGame/Binaries/Linux/ShooterGameServer"
   chmod +x "${ARK_SERVER_VOLUME}/server/ShooterGame/Binaries/Linux/ShooterGameServer"
 
-  if ! ${ARKMANAGER} install @main --verbose "${BETA_ARGS[@]}"; then
+  if [[ -n "${TARGET_MANIFEST_ID}" ]]; then
+    install_pinned_manifest
+  elif ! ${ARKMANAGER} install @main --verbose "${BETA_ARGS[@]}"; then
     echo "ERROR: Installation failed - check the steamcmd output above."
     echo "       Common causes: not enough disk space ($(df -Ph "${ARK_SERVER_VOLUME}" | awk 'NR==2 {print $4}') left on ${ARK_SERVER_VOLUME}), network hiccups."
     exit 1

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -258,9 +258,21 @@ function read_pin_field() {
 
 function installed_steam_buildid() {
   local -r ACF="${ARK_SERVER_VOLUME}/server/steamapps/appmanifest_${ARK_APP_ID}.acf"
+  local BUILDID
 
-  [[ -f "${ACF}" ]] || return 0
-  sed -n 's/.*"buildid"[^0-9]*"\([0-9]*\)".*/\1/p' "${ACF}" | head -n1
+  [[ -f "${ACF}" ]] || { echo "none"; return 0; }
+
+  # an appmanifest that exists but cannot be parsed (a torn write, say) must
+  # not read the same as no appmanifest at all, or it passes as "unchanged"
+  BUILDID="$(sed -n 's/.*"buildid"[^0-9]*"\([0-9]*\)".*/\1/p' "${ACF}" | head -n1)"
+  echo "${BUILDID:-unreadable}"
+}
+
+function server_binary_fingerprint() {
+  local -r SERVER_EXEC="${ARK_SERVER_VOLUME}/server/ShooterGame/Binaries/Linux/ShooterGameServer"
+
+  [[ -s "${SERVER_EXEC}" ]] || { echo "none"; return 0; }
+  cksum < "${SERVER_EXEC}" | awk '{print $1"-"$2}'
 }
 
 function needs_install() {
@@ -277,19 +289,25 @@ function needs_install() {
       return 0
     fi
 
-    # arkmanager rewrites the appmanifest every time it runs app_update, e.g.
-    # from a cron 'arkmanager update' - a changed build id is the only trace
-    # left when something replaced the pinned binaries behind our back
-    if [[ "$(read_pin_field buildid)" != "$(installed_steam_buildid)" ]]; then
-      echo "The Steam build id changed since this server was pinned - something updated it, re-applying the pin ..."
-      return 0
-    fi
-
     # download_depot writes no appmanifest and the ARK depot ships no
     # version.txt, so the pin file plus the unpacked depot is the only proof
     # that a pinned install ever completed
     if [ ! -s "${SERVER_EXEC}" ] || [ ! -d "${SERVER_DIR}/Engine" ]; then
       echo "The pinned server files are not complete ..."
+      return 0
+    fi
+
+    # arkmanager rewrites the appmanifest every time it runs app_update, e.g.
+    # from a cron 'arkmanager update'
+    if [[ "$(read_pin_field buildid)" != "$(installed_steam_buildid)" ]]; then
+      echo "The Steam build id changed since this server was pinned - something updated it, re-applying the pin ..."
+      return 0
+    fi
+
+    # a repair that rewrites the binaries without touching Steam's bookkeeping
+    # leaves the build id alone, so compare the binary itself as well
+    if [[ "$(read_pin_field binary)" != "$(server_binary_fingerprint)" ]]; then
+      echo "The server binary changed since this server was pinned - something replaced it, re-applying the pin ..."
       return 0
     fi
 
@@ -324,6 +342,16 @@ function filesystem_of() {
   df -P "${1}" 2>/dev/null | awk 'NR==2 {print $1}'
 }
 
+function depot_staging_root() {
+  local FOUND
+
+  # steamcmd does not always stage below the same directory, and a mounted
+  # Steam session volume can move it to another filesystem - measure a
+  # steamapps directory it created itself before falling back to a guess
+  FOUND="$(find "${STEAM_HOME}" -maxdepth 4 -type d -name steamapps -print -quit 2>/dev/null)"
+  echo "${FOUND:-${STEAM_HOME}}"
+}
+
 function assert_free_disk_space_on() {
   local -r TARGET="${1}"
   local -r REQUIRED_MB="${2}"
@@ -344,7 +372,7 @@ function assert_free_disk_space() {
   # a fresh ARK install needs roughly 25GB (plus staging/backup headroom)
   local -r REQUIRED_MB="25000"
   local -a TARGETS=() AMOUNTS=()
-  local CANDIDATE NEEDED SEEN_EARLIER
+  local NEEDED SEEN_EARLIER
   local -i I J
 
   if [[ "${SKIP_DISK_CHECK}" == "true" ]]; then
@@ -361,15 +389,10 @@ function assert_free_disk_space() {
   fi
 
   # download_depot ignores force_install_dir and always stages the full depot
-  # below steamcmd's home first, on every pinned install. Which directory it
-  # picks there is not fixed, and a mounted Steam session volume can put one
-  # of them on a different filesystem, so require the space on both.
+  # below steamcmd's home first, on every pinned install
   if [[ -n "${TARGET_MANIFEST_ID}" ]]; then
-    for CANDIDATE in "${STEAM_HOME}" "${STEAM_HOME}/Steam"; do
-      [[ -d "${CANDIDATE}" ]] || continue
-      TARGETS+=("${CANDIDATE}")
-      AMOUNTS+=("${REQUIRED_MB}")
-    done
+    TARGETS+=("$(depot_staging_root)")
+    AMOUNTS+=("${REQUIRED_MB}")
   fi
 
   # on a default Docker host all of these live on the same device, where only
@@ -462,14 +485,37 @@ function verified_depot_path() {
   echo "${DEPOT_PATH}"
 }
 
+function report_kept_staging() {
+  local DEPOT_DIR
+
+  DEPOT_DIR="$(find_downloaded_depot "${ARK_CONTENT_DEPOT_ID}")"
+  [[ -n "${DEPOT_DIR}" ]] || return 0
+  echo "       The partial download was kept so a restart can resume it:"
+  echo "       ${DEPOT_DIR} ($(du -sh "${DEPOT_DIR}" 2>/dev/null | cut -f1) so far)."
+  echo "       Delete it by hand if you would rather have the disk space back."
+}
+
+function remove_depot_staging() {
+  local -r DEPOT_ID="${1}"
+  local DEPOT_DIR
+
+  DEPOT_DIR="$(find_downloaded_depot "${DEPOT_ID}")"
+  [[ -n "${DEPOT_DIR}" ]] || return 0
+  echo "...removing the staged download in ${DEPOT_DIR}"
+  rm -rf "${DEPOT_DIR}"
+}
+
 function install_depot_files() {
   local -r DEPOT_DIR="${1}"
 
   echo "...moving ${DEPOT_DIR} into ${ARK_SERVER_VOLUME}/server"
   if ! cp -a "${DEPOT_DIR}/." "${ARK_SERVER_VOLUME}/server/"; then
     echo "ERROR: could not copy ${DEPOT_DIR} into ${ARK_SERVER_VOLUME}/server - out of disk space?"
-    echo "       Removing the downloaded depot so the next attempt has room again."
-    rm -rf "${DEPOT_DIR}"
+    echo "       The server directory now holds a half-swapped mix of two builds; the pin was"
+    echo "       already dropped, so the next start reinstalls it from scratch."
+    echo "       Removing the downloaded depots so that attempt has room again."
+    remove_depot_staging "${ARK_CONTENT_DEPOT_ID}"
+    remove_depot_staging "${ARK_REDIST_DEPOT_ID}"
     exit 1
   fi
   # steamcmd never cleans up its download directory, and leaving it behind
@@ -484,13 +530,7 @@ function backup_before_binary_swap() {
   [[ -n "$(find "${SAVED_DIR}" -mindepth 1 -maxdepth 2 -name '*.ark' -print -quit 2>/dev/null)" ]] || return 0
 
   echo "Creating a backup before swapping the server binaries (\$PRE_UPDATE_BACKUP is 'true')..."
-  if ! ${ARKMANAGER} backup @main; then
-    echo "ERROR: the backup failed, refusing to swap the server binaries."
-    echo "       A pin usually moves the server to an older build, and an older build rewrites"
-    echo "       the saves it loads on the first autosave - going ahead risks the world."
-    echo "       Fix the backup, or set PRE_UPDATE_BACKUP=false to swap without one."
-    exit 1
-  fi
+  ${ARKMANAGER} backup @main
 }
 
 function install_pinned_manifest() {
@@ -510,6 +550,9 @@ function install_pinned_manifest() {
     echo "       download_depot was never taught the manifest request codes Steam introduced in 2021,"
     echo "       so for some older manifests it quietly downloads the current build instead."
     echo "       Refusing to install that - it would put the build you are escaping back on disk."
+    echo "       Retrying would fetch the same wrong build, so the download is not kept."
+    remove_depot_staging "${ARK_CONTENT_DEPOT_ID}"
+    remove_depot_staging "${ARK_REDIST_DEPOT_ID}"
     exit 1
   fi
   if (( RESULT != 0 )); then
@@ -518,11 +561,25 @@ function install_pinned_manifest() {
     echo "       Verify the manifest id on https://steamdb.info/depot/${ARK_CONTENT_DEPOT_ID}/manifests/"
     echo "       'Manifest not available' means this account cannot see that manifest - set STEAM_LOGIN"
     echo "       to an account that owns ARK and mount a Steam session (see the README)."
-    echo "       The partial download was kept so a restart can resume it."
+    report_kept_staging
+    remove_depot_staging "${ARK_REDIST_DEPOT_ID}"
     exit 1
   fi
 
-  backup_before_binary_swap
+  if ! backup_before_binary_swap; then
+    echo "ERROR: the backup failed, refusing to swap the server binaries."
+    echo "       A pin usually moves the server to an older build, and an older build rewrites"
+    echo "       the saves it loads on the first autosave - going ahead risks the world."
+    echo "       Fix the backup, or set PRE_UPDATE_BACKUP=false to swap without one."
+    remove_depot_staging "${ARK_CONTENT_DEPOT_ID}"
+    remove_depot_staging "${ARK_REDIST_DEPOT_ID}"
+    exit 1
+  fi
+
+  # from here the server directory is a mix of two builds until the last copy
+  # lands - drop the pin first so an aborted swap can never be mistaken for a
+  # finished one on the next start
+  rm -f "${MANIFEST_PIN_FILE}"
 
   install_depot_files "${CONTENT_DIR}"
   # download_depot hands the files over without the executable bit, unlike the
@@ -539,7 +596,9 @@ function install_pinned_manifest() {
     echo "WARNING: depot ${ARK_REDIST_DEPOT_ID} (Steamworks redistributables) did not download, continuing..."
   fi
 
-  printf 'manifest=%s\nbuildid=%s\n' "${TARGET_MANIFEST_ID}" "$(installed_steam_buildid)" > "${MANIFEST_PIN_FILE}"
+  printf 'manifest=%s\nbuildid=%s\nbinary=%s\n' \
+    "${TARGET_MANIFEST_ID}" "$(installed_steam_buildid)" "$(server_binary_fingerprint)" \
+    > "${MANIFEST_PIN_FILE}"
 }
 
 function add_cluster_to_arkmanager_cfg() {

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -345,11 +345,14 @@ function filesystem_of() {
 function depot_staging_root() {
   local FOUND
 
-  # steamcmd does not always stage below the same directory, and a mounted
-  # Steam session volume can move it to another filesystem - measure a
-  # steamapps directory it created itself before falling back to a guess
-  FOUND="$(find "${STEAM_HOME}" -maxdepth 4 -type d -name steamapps -print -quit 2>/dev/null)"
-  echo "${FOUND:-${STEAM_HOME}}"
+  # download_depot unpacks below steamcmd's own directory, e.g.
+  # /home/steam/steamcmd/linux32/steamapps/content/app_376030/depot_376031 -
+  # never below the Steam session directory that STEAM_LOGIN mounts, so a
+  # mounted session volume does not hold the staging copy
+  [[ -d "${STEAM_HOME}/steamcmd" ]] || { echo "${STEAM_HOME}"; return 0; }
+
+  FOUND="$(find "${STEAM_HOME}/steamcmd" -maxdepth 3 -type d -name steamapps -print -quit 2>/dev/null)"
+  echo "${FOUND:-${STEAM_HOME}/steamcmd}"
 }
 
 function assert_free_disk_space_on() {
@@ -415,10 +418,10 @@ function assert_free_disk_space() {
 function find_downloaded_depot() {
   local -r DEPOT_ID="${1}"
 
-  # match on the depot id alone: depot 1006 belongs to app 1007, so steamcmd
-  # files it under a different app directory than the one we asked for. The
-  # depth limit keeps find out of the ~22GB of depot content below the match.
-  find "${STEAM_HOME}" -maxdepth 6 -type d \
+  # for app 376030 steamcmd files both depots under app_376030, but the app
+  # directory of a shared depot is not guaranteed, so match on the depot id.
+  # The depth limit keeps find out of the ~22GB of content below the match.
+  find "${STEAM_HOME}" -maxdepth 7 -type d \
     -path "*/content/app_*/depot_${DEPOT_ID}" -print -quit 2>/dev/null
 }
 
@@ -428,6 +431,20 @@ function find_cached_manifest() {
 
   find "${STEAM_HOME}" -maxdepth 5 -type f \
     -name "${DEPOT_ID}_${MANIFEST_ID}.manifest" -print -quit 2>/dev/null
+}
+
+function warm_steam_app_info() {
+  # download_depot fails with "missing app info (Missing configuration)" until
+  # the app info sits in steamcmd's cache, and +app_info_update alone does not
+  # put it there - only a following +app_info_print does. That prints a few
+  # hundred KB of VDF, so this runs on its own and logs instead of printing.
+  echo "Loading the Steam app info for ${ARK_APP_ID} (download_depot needs it cached)..."
+  "${STEAM_HOME}/steamcmd/steamcmd.sh" \
+    +@NoPromptForPassword 1 \
+    +login "${STEAM_LOGIN}" \
+    +app_info_update 1 \
+    +app_info_print "${ARK_APP_ID}" \
+    +quit >> "${PINNED_INSTALL_LOG}" 2>&1 || true
 }
 
 function steamcmd_download_depot() {
@@ -445,7 +462,7 @@ function steamcmd_download_depot() {
 
   "${STEAM_HOME}/steamcmd/steamcmd.sh" \
     +@NoPromptForPassword 1 \
-    +login "${STEAM_LOGIN:-anonymous}" \
+    +login "${STEAM_LOGIN}" \
     "${DEPOT_ARGS[@]}" \
     +quit 2>&1 | tee -a "${PINNED_INSTALL_LOG}" || true
 }
@@ -458,12 +475,14 @@ function verified_depot_path() {
   local LINE DEPOT_PATH REPORTED_MANIFEST CROSS_CHECKED=""
 
   # steamcmd's exit status is useless (it reports success for downloads that
-  # never happened), this line is its only completeness signal
+  # never happened), this line is its only completeness signal. It looks like
+  #   Depot download complete : "/home/steam/steamcmd/linux32\steamapps\content\app_376030\depot_1006" (manifest 6403079453713498174)
+  # so the path in it mixes separators and does not exist as written - read
+  # only the manifest id from the line and locate the directory with find
   LINE="$(grep -i 'depot download complete' "${PINNED_INSTALL_LOG}" | grep -F "depot_${DEPOT_ID}" | tail -n1)"
   [[ -n "${LINE}" ]] || return 1
 
-  DEPOT_PATH="$(sed -n 's/.*"\([^"]*\)".*/\1/p' <<< "${LINE}")"
-  [[ -d "${DEPOT_PATH}" ]] || DEPOT_PATH="$(find_downloaded_depot "${DEPOT_ID}")"
+  DEPOT_PATH="$(find_downloaded_depot "${DEPOT_ID}")"
   [[ -d "${DEPOT_PATH}" ]] || return 1
 
   if [[ -n "${EXPECTED_MANIFEST}" ]]; then
@@ -483,6 +502,27 @@ function verified_depot_path() {
   fi
 
   echo "${DEPOT_PATH}"
+}
+
+function explain_steamcmd_failure() {
+  if grep -qi 'No subscription\|missing license' "${PINNED_INSTALL_LOG}"; then
+    echo "       steamcmd reports no licence for depot ${ARK_CONTENT_DEPOT_ID}, so the account"
+    echo "       '${STEAM_LOGIN}' cannot download it. Use an account that owns ARK: Survival Evolved."
+
+    return
+  fi
+
+  if grep -qi 'missing app info\|Missing configuration' "${PINNED_INSTALL_LOG}"; then
+    echo "       steamcmd could not load the app info it needs for download_depot."
+    echo "       That is usually a login that did not go through - re-create the Steam session"
+    echo "       with deploy/steam-login.sh (see the README)."
+
+    return
+  fi
+
+  echo "       Verify the manifest id on https://steamdb.info/depot/${ARK_CONTENT_DEPOT_ID}/manifests/"
+  echo "       'Manifest not available' means this account cannot see that manifest, which"
+  echo "       happens for manifests that only ever existed on a beta branch."
 }
 
 function report_kept_staging() {
@@ -541,6 +581,7 @@ function install_pinned_manifest() {
   echo "arkmanager cannot pass a manifest to steamcmd, so this bypasses it and calls steamcmd directly."
 
   : > "${PINNED_INSTALL_LOG}"
+  warm_steam_app_info
   steamcmd_download_depot "${ARK_REDIST_DEPOT_ID}" ""
   steamcmd_download_depot "${ARK_CONTENT_DEPOT_ID}" "${TARGET_MANIFEST_ID}"
 
@@ -558,9 +599,7 @@ function install_pinned_manifest() {
   if (( RESULT != 0 )); then
     echo "ERROR: steamcmd did not finish downloading depot ${ARK_CONTENT_DEPOT_ID} at manifest ${TARGET_MANIFEST_ID}."
     echo "       Its full output is in ${PINNED_INSTALL_LOG}."
-    echo "       Verify the manifest id on https://steamdb.info/depot/${ARK_CONTENT_DEPOT_ID}/manifests/"
-    echo "       'Manifest not available' means this account cannot see that manifest - set STEAM_LOGIN"
-    echo "       to an account that owns ARK and mount a Steam session (see the README)."
+    explain_steamcmd_failure
     report_kept_staging
     remove_depot_staging "${ARK_REDIST_DEPOT_ID}"
     exit 1
@@ -993,6 +1032,19 @@ if [[ -n "${TARGET_MANIFEST_ID}" ]]; then
   if [[ ! "${TARGET_MANIFEST_ID}" =~ ^[0-9]+$ ]]; then
     echo "ERROR: TARGET_MANIFEST_ID='${TARGET_MANIFEST_ID}' must be a plain numeric Steam manifest id."
     echo "       Look it up on https://steamdb.info/depot/${ARK_CONTENT_DEPOT_ID}/manifests/"
+    exit 1
+  fi
+
+  # steamcmd refuses download_depot for the anonymous account with
+  # "missing license for depot (No subscription)", even though app_update of
+  # the same app works anonymously - fail here instead of after a long download
+  if [[ -z "${STEAM_LOGIN}" ]] || [[ "${STEAM_LOGIN}" == "anonymous" ]]; then
+    echo "ERROR: TARGET_MANIFEST_ID needs a Steam account that owns ARK: Survival Evolved."
+    echo "       steamcmd only allows the anonymous account to run app_update, not"
+    echo "       download_depot, which is the only way to ask for a specific build:"
+    echo "         Depot download failed : missing license for depot (No subscription)"
+    echo "       Set STEAM_LOGIN and mount a Steam session, see the README section"
+    echo "       'Configure a Steam login session'."
     exit 1
   fi
 

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -299,14 +299,14 @@ function needs_install() {
 
     # arkmanager rewrites the appmanifest every time it runs app_update, e.g.
     # from a cron 'arkmanager update'
-    if [[ "$(read_pin_field buildid)" != "$(installed_steam_buildid)" ]]; then
+    if [[ "$(read_pin_field buildid_at_pin)" != "$(installed_steam_buildid)" ]]; then
       echo "The Steam build id changed since this server was pinned - something updated it, re-applying the pin ..."
       return 0
     fi
 
     # a repair that rewrites the binaries without touching Steam's bookkeeping
     # leaves the build id alone, so compare the binary itself as well
-    if [[ "$(read_pin_field binary)" != "$(server_binary_fingerprint)" ]]; then
+    if [[ "$(read_pin_field binary_at_pin)" != "$(server_binary_fingerprint)" ]]; then
       echo "The server binary changed since this server was pinned - something replaced it, re-applying the pin ..."
       return 0
     fi
@@ -506,8 +506,11 @@ function verified_depot_path() {
 
 function explain_steamcmd_failure() {
   if grep -qi 'No subscription\|missing license' "${PINNED_INSTALL_LOG}"; then
-    echo "       steamcmd reports no licence for depot ${ARK_CONTENT_DEPOT_ID}, so the account"
-    echo "       '${STEAM_LOGIN}' cannot download it. Use an account that owns ARK: Survival Evolved."
+    echo "       steamcmd reports no licence for depot ${ARK_CONTENT_DEPOT_ID}. Either the Steam"
+    echo "       session for '${STEAM_LOGIN}' has expired, which is the common case on a server"
+    echo "       that ran fine yesterday, or that account does not own ARK: Survival Evolved."
+    echo "       Re-create the session with deploy/steam-login.sh first (see the README), and"
+    echo "       only look for another account if the fresh session fails the same way."
 
     return
   fi
@@ -525,14 +528,47 @@ function explain_steamcmd_failure() {
   echo "       happens for manifests that only ever existed on a beta branch."
 }
 
+function staging_marker_of() {
+  local -r DEPOT_DIR="${1}"
+
+  # derive the depot id from the directory so that clearing one depot's staging
+  # cannot remove another depot's marker - they share a parent directory
+  echo "$(dirname "${DEPOT_DIR}")/.ark_requested_manifest_${DEPOT_DIR##*/depot_}"
+}
+
 function report_kept_staging() {
   local DEPOT_DIR
 
   DEPOT_DIR="$(find_downloaded_depot "${ARK_CONTENT_DEPOT_ID}")"
   [[ -n "${DEPOT_DIR}" ]] || return 0
+
+  # download_depot unpacks into content/app_<id>/depot_<id>, a path with no
+  # manifest in it, so a kept partial download is indistinguishable from one
+  # for another manifest - label it, reset_stale_content_staging reads this
+  echo "${TARGET_MANIFEST_ID}" > "$(staging_marker_of "${DEPOT_DIR}")"
+
   echo "       The partial download was kept so a restart can resume it:"
   echo "       ${DEPOT_DIR} ($(du -sh "${DEPOT_DIR}" 2>/dev/null | cut -f1) so far)."
   echo "       Delete it by hand if you would rather have the disk space back."
+}
+
+function reset_stale_content_staging() {
+  local DEPOT_DIR
+
+  DEPOT_DIR="$(find_downloaded_depot "${ARK_CONTENT_DEPOT_ID}")"
+  [[ -n "${DEPOT_DIR}" ]] || return 0
+
+  # only a download that was kept for this exact manifest may be resumed;
+  # anything else would let steamcmd write this build over another build's
+  # files and hand the mixture on as verified
+  if [[ "$(cat "$(staging_marker_of "${DEPOT_DIR}")" 2>/dev/null)" == "${TARGET_MANIFEST_ID}" ]]; then
+    echo "...resuming the staged download for manifest ${TARGET_MANIFEST_ID}"
+
+    return 0
+  fi
+
+  echo "...discarding a staged download that was not for manifest ${TARGET_MANIFEST_ID}"
+  rm -rf "${DEPOT_DIR}" "$(staging_marker_of "${DEPOT_DIR}")"
 }
 
 function remove_depot_staging() {
@@ -542,7 +578,7 @@ function remove_depot_staging() {
   DEPOT_DIR="$(find_downloaded_depot "${DEPOT_ID}")"
   [[ -n "${DEPOT_DIR}" ]] || return 0
   echo "...removing the staged download in ${DEPOT_DIR}"
-  rm -rf "${DEPOT_DIR}"
+  rm -rf "${DEPOT_DIR}" "$(staging_marker_of "${DEPOT_DIR}")"
 }
 
 function install_depot_files() {
@@ -581,6 +617,7 @@ function install_pinned_manifest() {
   echo "arkmanager cannot pass a manifest to steamcmd, so this bypasses it and calls steamcmd directly."
 
   : > "${PINNED_INSTALL_LOG}"
+  reset_stale_content_staging
   warm_steam_app_info
   steamcmd_download_depot "${ARK_REDIST_DEPOT_ID}" ""
   steamcmd_download_depot "${ARK_CONTENT_DEPOT_ID}" "${TARGET_MANIFEST_ID}"
@@ -631,11 +668,24 @@ function install_pinned_manifest() {
   REDIST_DIR="$(verified_depot_path "${ARK_REDIST_DEPOT_ID}" "")" || RESULT=$?
   if (( RESULT == 0 )); then
     install_depot_files "${REDIST_DIR}"
+  elif [[ -s "${ARK_SERVER_VOLUME}/server/linux64/steamclient.so" ]]; then
+    echo "WARNING: depot ${ARK_REDIST_DEPOT_ID} (Steamworks redistributables) did not download,"
+    echo "         keeping the copy that is already installed."
   else
-    echo "WARNING: depot ${ARK_REDIST_DEPOT_ID} (Steamworks redistributables) did not download, continuing..."
+    echo "ERROR: depot ${ARK_REDIST_DEPOT_ID} (Steamworks redistributables) did not download and"
+    echo "       server/linux64/steamclient.so is not installed either. The server cannot start"
+    echo "       without it, so this install stays unpinned and the next start retries it."
+    echo "       Its full output is in ${PINNED_INSTALL_LOG}."
+    explain_steamcmd_failure
+    exit 1
   fi
 
-  printf 'manifest=%s\nbuildid=%s\nbinary=%s\n' \
+  # Steam's own metadata still describes the build this pin replaced. Leaving
+  # it lets arkmanager and the staged-update cron examples compare a build that
+  # is not installed against the latest one and act on the difference.
+  rm -f "${ARK_SERVER_VOLUME}/server/steamapps/appmanifest_${ARK_APP_ID}.acf"
+
+  printf 'manifest=%s\nbuildid_at_pin=%s\nbinary_at_pin=%s\n' \
     "${TARGET_MANIFEST_ID}" "$(installed_steam_buildid)" "$(server_binary_fingerprint)" \
     > "${MANIFEST_PIN_FILE}"
 }
@@ -1142,11 +1192,22 @@ fi
 heal_config_symlinks
 
 if [[ -z "${TARGET_MANIFEST_ID}" ]] && [[ -f "${MANIFEST_PIN_FILE}" ]]; then
-  echo "TARGET_MANIFEST_ID is no longer set, removing the manifest pin."
+  echo "TARGET_MANIFEST_ID is no longer set, removing the manifest pin (it was $(read_pin_field manifest))."
+  echo "If you did not mean to un-pin, stop the container now: an empty TARGET_MANIFEST_ID is all"
+  echo "it takes, so a compose run without your env file lands here too."
   echo "The pinned install bypassed steamcmd's bookkeeping, so arkmanager cannot tell which build is"
   echo "on disk and would happily call it up to date. Dropping that bookkeeping forces a full"
   echo "steamcmd validate pass back to the current build, which takes a while but is the only"
   echo "way back to a server arkmanager can keep updated."
+
+  if ! backup_before_binary_swap; then
+    echo "ERROR: the backup failed, refusing to un-pin."
+    echo "       Un-pinning replaces the server binaries, and the saves were written by the"
+    echo "       pinned build - going ahead without a backup risks the world."
+    echo "       Fix the backup, or set PRE_UPDATE_BACKUP=false to un-pin without one."
+    exit 1
+  fi
+
   rm -f "${MANIFEST_PIN_FILE}" \
         "${ARK_SERVER_VOLUME}/server/steamapps/appmanifest_${ARK_APP_ID}.acf" \
         "${ARK_SERVER_VOLUME}/server/version.txt"
@@ -1187,6 +1248,11 @@ fi
 declare -a ALL_GAME_MOD_IDS=()
 mapfile -t ALL_GAME_MOD_IDS < <(get_all_mod_ids)
 if [[ ${#ALL_GAME_MOD_IDS[@]} -gt 0 ]]; then
+  if [[ -n "${TARGET_MANIFEST_ID}" ]]; then
+    echo "WARNING: mods cannot be pinned. The Workshop only ever serves their current version,"
+    echo "         which was built against the current server build, not the pinned one."
+  fi
+
   echo "Installing mods: '${ALL_GAME_MOD_IDS[*]}' ..."
 
   for MOD_ID in "${ALL_GAME_MOD_IDS[@]}"; do

--- a/conf.d/crontab
+++ b/conf.d/crontab
@@ -21,16 +21,23 @@ BASH_ENV=/app/environment
 # @all targets every instance - identical to @main on a single-map server,
 # and required on multi-map servers (an update swaps the shared binaries,
 # so it must stop/restart all instances, not just one)
+#
+# The [ -z "${TARGET_MANIFEST_ID}" ] guard on every update job is not optional.
+# arkmanager only ever updates to the newest build, so on a server pinned with
+# TARGET_MANIFEST_ID an update job undoes the pin and puts the build you are
+# escaping straight back. The pin is re-applied on the next container restart,
+# which can be days away.
+#
 # Example : update every day at 4am
-# 0 4 * * * arkmanager update @all --warn --update-mods >> /app/log/crontab.log 2>&1
+# 0 4 * * * [ -z "${TARGET_MANIFEST_ID}" ] && arkmanager update @all --warn --update-mods >> /app/log/crontab.log 2>&1
 #
 # The job above already downloads into /app/staging with the server running and
 # only stops it to swap the files. Split it in two only if you want the restart
 # to land at a fixed hour: download hourly, apply at 6am. The cmp guard is
 # required, without it the 6am job stops and restarts the server even when
 # staging holds the build you are already running. See the README.
-# 0 * * * * arkmanager update @all --downloadonly --update-mods >> /app/log/crontab.log 2>&1
-# 0 6 * * * cmp -s /app/server/steamapps/appmanifest_376030.acf /app/staging/steamapps/appmanifest_376030.acf || arkmanager update @all --no-download --update-mods --warn >> /app/log/crontab.log 2>&1
+# 0 * * * * [ -z "${TARGET_MANIFEST_ID}" ] && arkmanager update @all --downloadonly --update-mods >> /app/log/crontab.log 2>&1
+# 0 6 * * * [ -z "${TARGET_MANIFEST_ID}" ] && ! cmp -s /app/server/steamapps/appmanifest_376030.acf /app/staging/steamapps/appmanifest_376030.acf && arkmanager update @all --no-download --update-mods --warn >> /app/log/crontab.log 2>&1
 #
 # Example : backup every 15min
 # */15 * * * * arkmanager backup @all >> /app/log/crontab.log 2>&1

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -57,6 +57,9 @@ services:
       # # Health check behaviour, see the README section "Health check"
       #- DISABLE_HEALTHCHECK=true
       #- HEALTHCHECK_REQUIRE_ALL_INSTANCES=true
+      # # Escape hatch for a broken ARK update, see the README section
+      # # "Pin the server to a Steam manifest"
+      #- TARGET_MANIFEST_ID=${TARGET_MANIFEST_ID}
       # # Cluster / multi-map settings, see the README section
       # # "Cluster and multi-map support" for all SUB_<KEY>_* variables
       #- CLUSTER_ID=MyCluster

--- a/deploy/example.env
+++ b/deploy/example.env
@@ -12,6 +12,9 @@ SERVER_PASSWORD=YouShallNotPass
 ADMIN_PASSWORD=topsecret
 MAX_PLAYERS=20
 UPDATE_ON_START=true
+# Escape hatch for a broken ARK update: pin the server files to one Steam
+# manifest and stop updating, see README "Pin the server to a Steam manifest"
+#TARGET_MANIFEST_ID=6366771435093287465
 BACKUP_ON_STOP=false
 PRE_UPDATE_BACKUP=true
 WARN_ON_STOP=true

--- a/deploy/example.env
+++ b/deploy/example.env
@@ -13,7 +13,8 @@ ADMIN_PASSWORD=topsecret
 MAX_PLAYERS=20
 UPDATE_ON_START=true
 # Escape hatch for a broken ARK update: pin the server files to one Steam
-# manifest and stop updating, see README "Pin the server to a Steam manifest"
+# manifest and stop updating, see README "Pin the server to a Steam manifest".
+# Needs STEAM_LOGIN with an account that owns ARK, anonymous cannot do this.
 #TARGET_MANIFEST_ID=6366771435093287465
 BACKUP_ON_STOP=false
 PRE_UPDATE_BACKUP=true

--- a/tests/manifest_pin.bats
+++ b/tests/manifest_pin.bats
@@ -18,13 +18,21 @@ write_app_manifest() {
 }
 
 # a pinned install as install_pinned_manifest leaves it: depot files unpacked,
-# no appmanifest and no version.txt, and the image's own pin record
-install_pinned_files() {
-  mkdir -p "$(dirname "${SERVER_EXEC}")" "${SERVER_DIR}/Engine"
-  echo "pinned binary" > "${SERVER_EXEC}"
+# no version.txt, and the image's own pin record. The pin file is written out
+# literally rather than through the functions under test, so that a change to
+# the field names or to either fingerprint fails a test instead of moving with
+# it. PINNED_BINARY_CKSUM is the cksum of exactly the bytes written below.
+PINNED_BINARY="pinned binary"
+PINNED_BINARY_CKSUM="2398651004-14"
 
-  printf 'manifest=%s\nbuildid=%s\nbinary=%s\n' \
-    "${TARGET_MANIFEST_ID}" "$(installed_steam_buildid)" "$(server_binary_fingerprint)" \
+install_pinned_files() {
+  local buildid="${1:-none}"
+
+  mkdir -p "$(dirname "${SERVER_EXEC}")" "${SERVER_DIR}/Engine"
+  echo "${PINNED_BINARY}" > "${SERVER_EXEC}"
+
+  printf 'manifest=%s\nbuildid_at_pin=%s\nbinary_at_pin=%s\n' \
+    "${TARGET_MANIFEST_ID}" "${buildid}" "${PINNED_BINARY_CKSUM}" \
     > "${MANIFEST_PIN_FILE}"
 }
 
@@ -69,7 +77,7 @@ install_pinned_files() {
 
 @test "re-applies the pin when the steam build id changed" {
   write_app_manifest "111"
-  install_pinned_files
+  install_pinned_files "111"
   write_app_manifest "222"
 
   run needs_install
@@ -101,7 +109,7 @@ install_pinned_files() {
 
 @test "re-applies the pin when the server binary was replaced" {
   write_app_manifest "111"
-  install_pinned_files
+  install_pinned_files "111"
   echo "somebody else's binary" > "${SERVER_EXEC}"
 
   run needs_install
@@ -112,7 +120,7 @@ install_pinned_files() {
 }
 
 @test "an unpinned server ignores a leftover pin file" {
-  install_pinned_files
+  install_pinned_files "111"
   write_app_manifest "111"
   TARGET_MANIFEST_ID=""
 

--- a/tests/manifest_pin.bats
+++ b/tests/manifest_pin.bats
@@ -1,0 +1,187 @@
+#!/usr/bin/env bats
+
+load helper
+
+setup() {
+  load_entrypoint
+
+  SERVER_DIR="${ARK_SERVER_VOLUME}/server"
+  SERVER_EXEC="${SERVER_DIR}/ShooterGame/Binaries/Linux/ShooterGameServer"
+  APP_MANIFEST="${SERVER_DIR}/steamapps/appmanifest_376030.acf"
+
+  TARGET_MANIFEST_ID="6366771435093287465"
+}
+
+write_app_manifest() {
+  mkdir -p "$(dirname "${APP_MANIFEST}")"
+  printf '"AppState"\n{\n\t"appid"\t\t"376030"\n\t"buildid"\t\t"%s"\n}\n' "${1}" > "${APP_MANIFEST}"
+}
+
+# a pinned install as install_pinned_manifest leaves it: depot files unpacked,
+# no appmanifest and no version.txt, and the image's own pin record
+install_pinned_files() {
+  mkdir -p "$(dirname "${SERVER_EXEC}")" "${SERVER_DIR}/Engine"
+  echo "pinned binary" > "${SERVER_EXEC}"
+
+  printf 'manifest=%s\nbuildid=%s\nbinary=%s\n' \
+    "${TARGET_MANIFEST_ID}" "$(installed_steam_buildid)" "$(server_binary_fingerprint)" \
+    > "${MANIFEST_PIN_FILE}"
+}
+
+@test "wants an install when nothing is pinned yet" {
+  mkdir -p "$(dirname "${SERVER_EXEC}")" "${SERVER_DIR}/Engine"
+  echo "binary" > "${SERVER_EXEC}"
+
+  run needs_install
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "not pinned to manifest ${TARGET_MANIFEST_ID}"
+}
+
+@test "is satisfied by a completed pinned install" {
+  install_pinned_files
+
+  run needs_install
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "Already installed (pinned to manifest ${TARGET_MANIFEST_ID})"
+}
+
+@test "wants an install when the pin file names a different manifest" {
+  install_pinned_files
+  TARGET_MANIFEST_ID="385619103637186563"
+
+  run needs_install
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "not pinned to manifest 385619103637186563"
+}
+
+@test "wants an install when the depot did not land completely" {
+  install_pinned_files
+  rmdir "${SERVER_DIR}/Engine"
+
+  run needs_install
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "pinned server files are not complete"
+}
+
+@test "re-applies the pin when the steam build id changed" {
+  write_app_manifest "111"
+  install_pinned_files
+  write_app_manifest "222"
+
+  run needs_install
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Steam build id changed"
+}
+
+@test "re-applies the pin when an update appears where there was no appmanifest" {
+  install_pinned_files
+  write_app_manifest "222"
+
+  run needs_install
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Steam build id changed"
+}
+
+@test "a truncated appmanifest counts as drift, not as no appmanifest" {
+  install_pinned_files
+  mkdir -p "$(dirname "${APP_MANIFEST}")"
+  printf '"AppState"\n{\n\t"appid"\t\t"376030"\n\t"buil' > "${APP_MANIFEST}"
+
+  run needs_install
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Steam build id changed"
+}
+
+@test "re-applies the pin when the server binary was replaced" {
+  write_app_manifest "111"
+  install_pinned_files
+  echo "somebody else's binary" > "${SERVER_EXEC}"
+
+  run needs_install
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "server binary changed"
+  assert_not_contains "$output" "Already installed"
+}
+
+@test "an unpinned server ignores a leftover pin file" {
+  install_pinned_files
+  write_app_manifest "111"
+  TARGET_MANIFEST_ID=""
+
+  run needs_install
+
+  [ "$status" -eq 1 ]
+  [ "$output" = "Already installed." ]
+}
+
+@test "reports no appmanifest and an unreadable one differently" {
+  run installed_steam_buildid
+  [ "$output" = "none" ]
+
+  write_app_manifest "4711"
+  run installed_steam_buildid
+  [ "$output" = "4711" ]
+
+  printf 'garbage' > "${APP_MANIFEST}"
+  run installed_steam_buildid
+  [ "$output" = "unreadable" ]
+}
+
+@test "fingerprints a missing server binary as none" {
+  run server_binary_fingerprint
+
+  [ "$output" = "none" ]
+}
+
+@test "checks the pin without calling arkmanager or steamcmd" {
+  install_pinned_files
+
+  run needs_install
+
+  assert_stubs_installed_and_unused
+}
+
+@test "a pinned install needs room for the volume and the staging copy" {
+  export STEAM_HOME="${BATS_TEST_TMPDIR}/steamhome"
+  mkdir -p "${STEAM_HOME}/steamcmd"
+  SKIP_DISK_CHECK="false"
+  stub_df_available_mb 30000
+
+  run assert_free_disk_space
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "~50000MB required"
+}
+
+@test "a re-pin only needs room for the staging copy" {
+  export STEAM_HOME="${BATS_TEST_TMPDIR}/steamhome"
+  mkdir -p "${STEAM_HOME}/steamcmd" "${ARK_SERVER_VOLUME}/server/ShooterGame/Content"
+  SKIP_DISK_CHECK="false"
+  stub_df_available_mb 30000
+
+  run assert_free_disk_space
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "an unpinned install is not charged for a staging copy" {
+  export STEAM_HOME="${BATS_TEST_TMPDIR}/steamhome"
+  mkdir -p "${STEAM_HOME}/steamcmd"
+  TARGET_MANIFEST_ID=""
+  SKIP_DISK_CHECK="false"
+  stub_df_available_mb 30000
+
+  run assert_free_disk_space
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}

--- a/tests/pinned_install.bats
+++ b/tests/pinned_install.bats
@@ -1,0 +1,266 @@
+#!/usr/bin/env bats
+
+# Covers install_pinned_manifest and the helpers it drives, against a steamcmd
+# stub that mimics the real one on Linux: the depot lands below
+# steamcmd/linux32/steamapps, the depotcache entry lands below Steam/, the
+# completion line mixes path separators and carries no file count, the ARK
+# depot ships no version.txt and no executable bit.
+
+load helper
+
+setup() {
+  load_entrypoint
+
+  SERVER_DIR="${ARK_SERVER_VOLUME}/server"
+  SERVER_EXEC="${SERVER_DIR}/ShooterGame/Binaries/Linux/ShooterGameServer"
+  APP_MANIFEST="${SERVER_DIR}/steamapps/appmanifest_376030.acf"
+
+  export STEAM_HOME="${BATS_TEST_TMPDIR}/steamhome"
+  export STEAM_LOGIN="ark_owner"
+  export STUB_MODE="ok"
+  mkdir -p "${STEAM_HOME}/steamcmd" "${ARK_SERVER_VOLUME}/log" "${SERVER_DIR}"
+
+  TARGET_MANIFEST_ID="6740753408000000000"
+  PRE_UPDATE_BACKUP="false"
+  ARKMANAGER="$(command -v arkmanager)"
+
+  DEPOT_ROOT="${STEAM_HOME}/steamcmd/linux32/steamapps/content/app_376030"
+  CONTENT_STAGING="${DEPOT_ROOT}/depot_376031"
+  REDIST_STAGING="${DEPOT_ROOT}/depot_1006"
+  STAGING_MARKER="${DEPOT_ROOT}/.ark_requested_manifest_376031"
+
+  write_steamcmd_stub
+}
+
+write_steamcmd_stub() {
+  cat > "${STEAM_HOME}/steamcmd/steamcmd.sh" <<'STUB'
+#!/usr/bin/env bash
+DEPOT_ID=""; MANIFEST_ID=""; IS_DOWNLOAD=""
+while [ $# -gt 0 ]; do
+  case "${1}" in
+    +download_depot)
+      IS_DOWNLOAD=1; DEPOT_ID="${3}"; MANIFEST_ID="${4:-}"
+      case "${MANIFEST_ID}" in +*) MANIFEST_ID="" ;; esac
+      ;;
+    +app_info_print) touch "${STEAM_HOME}/.appinfo_cached" ;;
+  esac
+  shift
+done
+[ -n "${IS_DOWNLOAD}" ] || exit 0
+
+DEPOT_DIR="${STEAM_HOME}/steamcmd/linux32/steamapps/content/app_376030/depot_${DEPOT_ID}"
+LINE_PATH="${STEAM_HOME}/steamcmd/linux32\\steamapps\\content\\app_376030\\depot_${DEPOT_ID}"
+mkdir -p "${DEPOT_DIR}" "${STEAM_HOME}/Steam/depotcache"
+
+if [ "${DEPOT_ID}" = "1006" ]; then
+  case "${STUB_MODE}" in
+    noredist)
+      echo "Depot download failed : missing license for depot (No subscription)"
+      exit 1
+      ;;
+  esac
+  mkdir -p "${DEPOT_DIR}/linux64"
+  echo so > "${DEPOT_DIR}/linux64/steamclient.so"
+  echo " Depot download complete : \"${LINE_PATH}\" (manifest 6403079453713498174)"
+  exit 0
+fi
+
+mkdir -p "${DEPOT_DIR}/ShooterGame/Binaries/Linux" "${DEPOT_DIR}/Engine"
+echo "server binary for ${MANIFEST_ID}" > "${DEPOT_DIR}/ShooterGame/Binaries/Linux/ShooterGameServer"
+chmod 644 "${DEPOT_DIR}/ShooterGame/Binaries/Linux/ShooterGameServer"
+echo engine > "${DEPOT_DIR}/Engine/engine.bin"
+
+case "${STUB_MODE}" in
+  interrupted)
+    echo "Depot download failed : Manifest not available"
+    exit 1
+    ;;
+  wrongbuild)
+    echo " Depot download complete : \"${LINE_PATH}\" (manifest 6366771435093287465)"
+    touch "${STEAM_HOME}/Steam/depotcache/376031_6366771435093287465.manifest"
+    ;;
+  *)
+    echo " Depot download complete : \"${LINE_PATH}\" (manifest ${MANIFEST_ID})"
+    touch "${STEAM_HOME}/Steam/depotcache/376031_${MANIFEST_ID}.manifest"
+    ;;
+esac
+STUB
+  chmod +x "${STEAM_HOME}/steamcmd/steamcmd.sh"
+}
+
+assert_not_pinned() {
+  if [ -f "${MANIFEST_PIN_FILE}" ]; then
+    echo "expected no pin file, got:"
+    cat "${MANIFEST_PIN_FILE}"
+    return 1
+  fi
+}
+
+@test "a completed pinned install lands the depot, the redist and the pin" {
+  run install_pinned_manifest
+
+  [ "$status" -eq 0 ]
+  [ -x "${SERVER_EXEC}" ]
+  [ -s "${SERVER_DIR}/linux64/steamclient.so" ]
+  [ -d "${SERVER_DIR}/Engine" ]
+  assert_contains "$(cat "${MANIFEST_PIN_FILE}")" "manifest=${TARGET_MANIFEST_ID}"
+}
+
+@test "the pin file records the build id and binary as its own fields" {
+  install_pinned_manifest
+
+  run cat "${MANIFEST_PIN_FILE}"
+
+  assert_contains "$output" "buildid_at_pin=none"
+  assert_contains "$output" "binary_at_pin=$(cksum < "${SERVER_EXEC}" | awk '{print $1"-"$2}')"
+}
+
+@test "a completed pinned install leaves no staging behind" {
+  install_pinned_manifest
+
+  [ ! -d "${CONTENT_STAGING}" ]
+  [ ! -d "${REDIST_STAGING}" ]
+}
+
+@test "a pinned install drops the appmanifest of the build it replaced" {
+  mkdir -p "$(dirname "${APP_MANIFEST}")"
+  echo "old build" > "${APP_MANIFEST}"
+
+  install_pinned_manifest
+
+  [ ! -f "${APP_MANIFEST}" ]
+}
+
+@test "a wrong manifest is refused and its download discarded" {
+  STUB_MODE="wrongbuild"
+
+  run install_pinned_manifest
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "did not deliver manifest ${TARGET_MANIFEST_ID}"
+  assert_not_pinned
+  [ ! -d "${CONTENT_STAGING}" ]
+  [ ! -d "${REDIST_STAGING}" ]
+}
+
+@test "an interrupted download is kept and labelled with its manifest" {
+  STUB_MODE="interrupted"
+
+  run install_pinned_manifest
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "did not finish downloading"
+  assert_not_pinned
+  [ -d "${CONTENT_STAGING}" ]
+  [ "$(cat "${STAGING_MARKER}")" = "${TARGET_MANIFEST_ID}" ]
+  [ ! -d "${REDIST_STAGING}" ]
+}
+
+@test "staging left over from another manifest is discarded, not written over" {
+  mkdir -p "${CONTENT_STAGING}/ShooterGame/Binaries/Linux"
+  echo "older build leftovers" > "${CONTENT_STAGING}/ShooterGame/Binaries/Linux/ShooterGameServer"
+  echo "dropped by the newer build" > "${CONTENT_STAGING}/stale.bin"
+  echo "385619103637186563" > "${STAGING_MARKER}"
+
+  run install_pinned_manifest
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "discarding a staged download"
+  [ "$(cat "${SERVER_EXEC}")" = "server binary for ${TARGET_MANIFEST_ID}" ]
+  [ ! -f "${SERVER_DIR}/stale.bin" ]
+}
+
+@test "staging kept for this manifest is resumed" {
+  mkdir -p "${CONTENT_STAGING}"
+  echo "${TARGET_MANIFEST_ID}" > "${STAGING_MARKER}"
+
+  run install_pinned_manifest
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "resuming the staged download"
+}
+
+@test "a missing redist is fatal when steamclient.so is not installed yet" {
+  STUB_MODE="noredist"
+
+  run install_pinned_manifest
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "steamclient.so is not installed either"
+  assert_not_pinned
+}
+
+@test "a missing redist is survivable when steamclient.so is already installed" {
+  STUB_MODE="noredist"
+  mkdir -p "${SERVER_DIR}/linux64"
+  echo so > "${SERVER_DIR}/linux64/steamclient.so"
+
+  run install_pinned_manifest
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "keeping the copy that is already installed"
+  assert_contains "$(cat "${MANIFEST_PIN_FILE}")" "manifest=${TARGET_MANIFEST_ID}"
+}
+
+@test "a failed backup stops the swap before anything is copied" {
+  PRE_UPDATE_BACKUP="true"
+  mkdir -p "${SERVER_DIR}/ShooterGame/Saved/SavedArks"
+  echo world > "${SERVER_DIR}/ShooterGame/Saved/SavedArks/TheIsland.ark"
+  ARKMANAGER="false"
+
+  run install_pinned_manifest
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "refusing to swap the server binaries"
+  assert_not_pinned
+  [ ! -f "${SERVER_EXEC}" ]
+  [ ! -d "${CONTENT_STAGING}" ]
+}
+
+@test "a copy that runs out of space leaves no pin and no staging" {
+  local bin_dir="${BATS_TEST_TMPDIR}/failbin"
+  mkdir -p "${bin_dir}"
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'case "$*" in *depot_376031*) echo "cp: No space left on device" >&2; exit 1 ;; esac'
+    echo 'exec /bin/cp "$@"'
+  } > "${bin_dir}/cp"
+  chmod +x "${bin_dir}/cp"
+  PATH="${bin_dir}:${PATH}"
+
+  run install_pinned_manifest
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "out of disk space"
+  assert_not_pinned
+  [ ! -d "${CONTENT_STAGING}" ]
+  [ ! -d "${REDIST_STAGING}" ]
+}
+
+@test "an expired session is not blamed on the wrong steam account" {
+  STUB_MODE="interrupted"
+
+  run install_pinned_manifest
+
+  assert_contains "$output" "Manifest not available"
+}
+
+@test "a licence failure names the session before the account" {
+  : > "${PINNED_INSTALL_LOG}"
+  echo "Depot download failed : missing license for depot (No subscription)" >> "${PINNED_INSTALL_LOG}"
+
+  run explain_steamcmd_failure
+
+  assert_contains "$output" "session for 'ark_owner' has expired"
+  assert_contains "$output" "deploy/steam-login.sh"
+}
+
+@test "a missing app info failure points at the session too" {
+  : > "${PINNED_INSTALL_LOG}"
+  echo "Depot download failed : missing app info (Missing configuration)" >> "${PINNED_INSTALL_LOG}"
+
+  run explain_steamcmd_failure
+
+  assert_contains "$output" "could not load the app info"
+  assert_contains "$output" "deploy/steam-login.sh"
+}


### PR DESCRIPTION
Closes #158

When Wildcard ships a broken build there is currently no way back. `UPDATE_ON_START` always pulls the newest one, and `BETA` only helps when a matching branch happens to exist. This adds `TARGET_MANIFEST_ID`, which pins the server files to one exact build of ARK's content depot.

Empty default, so nothing changes for anyone who does not set it.

## Read this first: pinning needs a Steam account that owns ARK

A normal install uses `steamcmd`'s `app_update`, which works with the anonymous account. Asking for one specific build needs `download_depot`, and Steam does not allow that anonymously. Tested against real steamcmd on Linux:

```
+login anonymous +app_info_update 1 +app_info_print 376030 +download_depot 376030 376031 6366771435093287465
Depot download failed : missing license for depot (No subscription)
```

`app_update 376030` on the same account works and preallocates the full 22.9GB, so this is a `download_depot` licence check, not an app entitlement problem.

That makes `STEAM_LOGIN` with an ARK-owning account a hard requirement for this feature. The entrypoint refuses to start with a pin and an anonymous login rather than downloading for an hour and failing at the end, and the README says so up front instead of the reverse. The requirement is acceptable: the people who need to roll back a broken build are running ARK servers and own ARK, the image already ships `deploy/steam-login.sh` and a documented session mount, and palworld-server-docker (the reference this issue cited) requires exactly the same thing for exactly the same reason.

## Can this go through arkmanager? No

Two independent blockers, both checked against the source:

* steamcmd's `app_update` takes no manifest argument. `download_depot <appid> <depotid> <manifestid>` is the only way to ask for a specific build.
* arkmanager has no `download_depot` support. Every install and update funnels through `runSteamCMDAppUpdate` into `+app_update "$appid" $steamcmd_appextraopts "$@"`. The only extension hooks are `steamcmd_appextraopts`, `steamcmd_cmds_prelogin` and `steamcmd_cmds_postlogin`, and none of them can turn `app_update` into a manifest pinned fetch. Checked both `v1.6.69` (the Dockerfile default) and current master.

So a pinned install calls steamcmd directly and copies the depot into the server directory. App 376030 has one content depot, **376031** (22.8GB), plus the Steamworks redistributables in depot **1006**, which is where `linux64/steamclient.so` comes from. Both are fetched.

## What real steamcmd does, and what the code had to learn

Verified on a Linux host in the built image, not reasoned about:

* **`+app_info_update 1` alone does not populate the app info cache.** `download_depot` fails with `missing app info (Missing configuration)` until a following `+app_info_print <appid>` has run. There is a warm-up call for it now, logged rather than printed because `app_info_print` dumps a few hundred KB of VDF.
* **The path in the completion line is unusable.** Real output is `Depot download complete : "/home/steam/steamcmd/linux32\steamapps\content\app_376030\depot_1006" (manifest 6403079453713498174)`, forward slashes and backslashes in one Unix path, and no file count. Only the manifest id is read from that line; the directory always comes from `find`. The format is quoted in a comment so nobody undoes it.
* **The depot lands in `/home/steam/steamcmd/linux32/steamapps/content/...`**, not under `/home/steam/Steam`. The disk gate measures the steamcmd directory, and the README no longer claims a mounted Steam session volume can hold the staging copy, because it cannot.
* **The depotcache entry is `${STEAM_HOME}/Steam/depotcache/<depot>_<manifest>.manifest`**, exactly the naming the manifest cross check assumes, and both depots are filed under `app_376030`. Both confirmed, unchanged.

## The hard part: nothing knows what is installed

Bypassing `app_update` also bypasses Steam's bookkeeping. No `steamapps/appmanifest_376030.acf` is written, and the ARK depot ships no `version.txt` either, so after a pinned install arkmanager cannot tell which build is on disk and the image's own "is it installed" check had nothing to look at.

The image therefore keeps its own record in `server/.ark_manifest_pin`: `manifest`, `buildid_at_pin` and `binary_at_pin` (a `cksum` of `ShooterGameServer`). The `_at_pin` suffixes are the honest description: those two fields say nothing has replaced the server since the pin, they do not identify which build is on disk. The pinned install also deletes `appmanifest_376030.acf`, because Steam's metadata would otherwise keep describing the build the pin replaced, and the staged update cron examples from #172 compare exactly that file.

**Verifying the download.** steamcmd's exit status is useless, it reports success for downloads that never happened, and "the directory exists" cannot tell a complete download from an interrupted one. Two signals are checked instead: the `Depot download complete` line, and the depotcache entry steamcmd leaves for the manifest it really fetched (any stale copy is removed first, so its presence proves this run). Nothing is copied that cannot be confirmed.

That second check matters more than it looks. `download_depot` never learned the manifest request codes Steam introduced in 2021, so for some older manifests it quietly downloads the *current* build into the same directory. Without the check, a user pinning to escape a broken build would get the broken build back, labelled as pinned. Now the install refuses and deletes the download, because retrying would fetch the same wrong build.

**The pin file is dropped before the first copy, not written after the last.** Between the content copy and the redist copy the server directory is a mix of two builds. If the pin file survives an aborted swap, the next start reports "Already installed" over half-swapped files, and reverting to the previous manifest does not help because that is exactly what the stale file claims to be. Dropping it up front means any aborted swap reinstalls.

**Drift.** An explicit `arkmanager update` from a cron job still updates and undoes the pin. Both recorded values are compared on every start, so that is caught and the pin re-applied. The binary checksum is there because the build id alone is a fingerprint of Steam's records rather than of the server: a repair that rewrites the binaries without touching the appmanifest leaves the build id unchanged. An appmanifest that exists but cannot be parsed is treated as drift, not as no appmanifest, so a torn write cannot read as "unchanged".

**Getting off a pin.** Clearing the variable used to leave the server on the downgraded binaries forever, because arkmanager read the stale build id and called them up to date. Un-pinning now throws that stale bookkeeping away, which sends the normal install path through a full `steamcmd` validate back to the current build. One slow start, then a server arkmanager can keep updated again.

**Keeping arkmanager away from steamcmd.** `may_update` is skipped and `UPDATE_ON_START` is forced to false while pinned, which also covers `arkAutoUpdateOnStart` and cron jobs (they read the same exported environment). To be precise: `arkmanager run`, which is what the entrypoint uses, does **not** auto update, `doRun` never calls `doUpdate`. Only `start` and `restart` reach `doStart` and its `arkAutoUpdateOnStart` check. So the forced flag covers a cron `restart`, it is not what holds the pin on a normal start. The pin file, the drift check and the skipped `may_update` are.

## Safety and resources

* **Backup before the swap.** A downgrade is worse for saves than an upgrade, the older binary loads saves written by the newer one and rewrites them on the first autosave. When `PRE_UPDATE_BACKUP` is true and there are saves, a backup runs before the binaries are swapped, and a failed backup aborts the swap.
* **Executable bit.** `download_depot` does not carry it, so it is re-applied to `ShooterGameServer`.
* **A missing redistributable depot is fatal** unless `server/linux64/steamclient.so` is already installed. Writing the pin without it would make every later start report "Already installed" over a container that crash loops on a missing library.
* **Kept staging is labelled with its manifest.** `download_depot` unpacks into a path with no manifest in it, so a partial download kept for one manifest would otherwise be written over by the next one and handed on as verified. Anything not labelled for the manifest being installed is discarded before the download.
* **Cron.** Every update job in `conf.d/crontab` and the README now carries a `[ -z "${TARGET_MANIFEST_ID}" ]` guard. Without it the staged update example applies an update on a pinned server as soon as Steam publishes anything, and the drift check would only notice at the next restart. A crontab created by an older image keeps its unguarded jobs, which the README calls out.
* **Disk.** A first pinned install needs ~50GB on a normal single disk host (~25GB staging plus ~25GB in the volume) and every later re-pin ~25GB. Requirements are summed per filesystem and the staging area is counted once, measured where the depot actually lands. `/home/steam/steamcmd` is the container's own filesystem, so hosts that cap the writable layer need that cap raised; the README says so.
* **Staging cleanup.** Removed after a successful copy, and on the wrong-manifest, failed-backup and failed-copy paths. The one exception is a download that was cut short, which is kept because it resumes; the error names the directory and its size.
* **Error messages.** No licence and no app info each get their own plain-language message instead of generic manifest advice.

## Files

* `Dockerfile`: `TARGET_MANIFEST_ID=""` in the ENV block.
* `bin/steam-entrypoint.sh`: validation including the anonymous-login refusal, app info warm-up, pinned install via `download_depot` with the verification above, pin state file, drift detection, un-pin repair, pre-swap backup, per filesystem disk gate, staging cleanup, steamcmd error translation.
* `README.md`: new "Pin the server to a Steam manifest (downgrade)" section (login requirement up front, SteamDB lookup, escape hatch not an everyday setting, what changes while pinned, what the drift check does and does not cover, disk, cluster warning), plus the env table rows.
* `AGENTS.md`: invariant describing why this bypasses arkmanager, plus the four verified steamcmd behaviours so nobody simplifies them away.
* `deploy/example.env`, `deploy/docker-compose.yml`: commented examples.

## Testing

`bats tests` -> 104 tests, all passing. `bash -n` and `shellcheck -x` clean on every changed script.

**Automated (`tests/`, 30 of those 104 are new here):**

* `tests/manifest_pin.bats` covers the pin bookkeeping: `needs_install` in pinned mode, both drift signals, a truncated appmanifest counting as drift rather than absence, an unpinned server ignoring a leftover pin file, `installed_steam_buildid`, `server_binary_fingerprint`, and the disk gate charging for the staging copy only when pinned. The pin file fixture is written out literally, not by calling the functions under test, so a change to a field name or a fingerprint format fails a test instead of moving with it (verified by mutation: renaming one field turns exactly one test red).
* `tests/pinned_install.bats` covers `install_pinned_manifest` end to end against a steamcmd stub that mimics the real one on Linux (depot below `steamcmd/linux32/steamapps`, depotcache below `Steam/`, completion line with mixed separators and no file count, no `version.txt`, no executable bit): success, wrong manifest, interrupted download, stale staging from another manifest, resumable staging for this manifest, missing redist with and without an installed `steamclient.so`, failed backup, `cp` running out of space, and `explain_steamcmd_failure`'s two branches. Every abort case asserts the pin file is absent afterwards, which is the property `AGENTS.md` calls the important one.

**Verified by hand, not automated:**

* Real steamcmd behaviour on a Linux host in the built image: the anonymous licence refusal, the `app_info_print` requirement, the completion line format, and where the depot actually lands. These need a real Steam login and a 22.8GB download, so they are recorded in `AGENTS.md` rather than tested.
* A 20 case end-to-end harness over the whole entrypoint (fresh install, restart, drift re-pin, un-pin, aborted swap then revert, disk gate arithmetic, anonymous refusal). It lives outside the repo because it drives the startup sequence rather than the functions, and the bats suite now covers the same ground at function level.

**Not covered by either:** `warm_steam_app_info`, `steamcmd_download_depot` and `verified_depot_path` are exercised only through `install_pinned_manifest`, so their behaviour against a steamcmd that differs from the stub is unknown until someone runs a real pinned install. The un-pin block and the anonymous refusal sit in the startup half below the `BASH_SOURCE` guard, which the suite deliberately never executes; both are covered by the harness only.

## Known limitations

* Needs a Steam account that owns ARK, see the top of this description. There is no way around it with `steamcmd`.
* The drift check covers the server executable and Steam's records, not the other ~22GB. A change limited to game content with the binary left alone is not noticed. It is a tripwire for the update paths this image has, not an integrity check, and the README says exactly that. It also only runs at startup, so an update that undoes the pin can serve players until the next restart, and re-applying the pin costs a full 22.8GB download.
* Mods cannot be pinned at all. The Workshop only serves a mod's current version and there is no manifest to ask for, so a pinned server installs mods built against the current build next to older binaries. Already installed mods are left alone, which is as close to freezing as it gets. The install warns and the README says so.
* Un-pinning is triggered by the variable being empty, so starting the container without your env file un-pins it. A backup is taken first and the log is explicit, but nothing asks for confirmation.
* A whole cluster has to be pinned to the same manifest. Mismatched builds sharing one `/cluster` volume can corrupt transfers. Documented, not enforced.
* Switching from one pin to another copies over the old files, it does not delete files the new build dropped. Documented, with the "delete `server/` and reinstall" way out.
* If `download_depot` cannot deliver a manifest at all, that build is out of reach with steamcmd. A DepotDownloader fallback would fix it but means adding a .NET tool to the image, which is a much bigger change than this escape hatch justifies.
