### PR TITLE
Back up the cluster directory (opt in)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,13 +181,16 @@ downstream compose files and scripts.
   entrypoints and exercises the pure-bash parts (sub instance keys and ports,
   generated sub instance configs, the `Game.ini` symlink healing, the
   declarative INI files, mod id collection, install detection, the directory
-  setup, the cluster config guard, the Discord config migration and its
-  hardcoded webhook warning, the disk space check, the appended
-  arkmanager.cfg blocks, the backup budget and crash restart validation, the
-  `running-instances` state file the healthcheck reads, the generated crontab
-  block). `tests/cron_schedule.bats` sources `bin/cron-schedule.sh` directly
-  rather than the entrypoint. It never installs a server, arkmanager and
-  steamcmd are stubbed in `tests/stubs`.
+  setup, the cluster config guard, the cluster backup opt-in and its
+  pre-update gate, the Discord config migration and its hardcoded webhook
+  warning, the disk space check, the appended arkmanager.cfg blocks, the
+  backup budget and crash restart validation, the `running-instances` state
+  file the healthcheck reads, the cron schedule validation and the generated
+  crontab block). `tests/cron_schedule.bats` sources `bin/cron-schedule.sh`
+  directly rather than the entrypoint, and `cluster_backup.bats` brings its own
+  arkmanager stub because it needs per-command exit codes and records the
+  environment the call was made with. It never installs a server, arkmanager
+  and steamcmd are stubbed in `tests/stubs`.
 - **Writing tests:** assert with `[ ... ]` or the helpers in
   `tests/helper.bash`, never with `[[ ... ]]`. macOS ships bash 3.2, where a
   failing non-final `[[ ... ]]` does not fail the test, so those assertions

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENV         IMAGE_VERSION="${IMAGE_VERSION}" \
             BACKUP_ON_STOP="false" \
             PRE_UPDATE_BACKUP="true" \
             MAX_BACKUP_SIZE_MB="" \
+            BACKUP_CLUSTER="false" \
             WARN_ON_STOP="true" \
             ALWAYS_RESTART_ON_CRASH="" \
             BACKUP_CRON="" \

--- a/README.md
+++ b/README.md
@@ -816,16 +816,16 @@ that restarts in a loop therefore does not write a backup on every boot. If
 that backup fails, the start aborts instead of updating without one, and
 `PRE_UPDATE_BACKUP=false` skips it entirely.
 
-**Check your retention limit first.** `arkmanager.cfg` ships
+**Check your retention limit first.** The bundled `arkmanager.cfg` ships
 `arkMaxBackupSizeMB="500"`. arkmanager applies that limit after *every single
 instance backup*, not once per run: it walks the backup directory newest
 first, keeps files up to the limit and deletes everything below it. So the
 tarballs of one `@all` run count against each other. Three maps that carry the
 cluster data each can blow the limit inside a single run and leave you with the
-newest tarball and no history at all. Raise `arkMaxBackupSizeMB` in
-`<your-volume>/arkmanager/arkmanager.cfg` before you turn `BACKUP_CLUSTER` on
-(an environment variable for it is on the way). The container prints the same
-warning on every start while the option is enabled.
+newest tarball and no history at all. Raise it with `MAX_BACKUP_SIZE_MB`
+before you turn `BACKUP_CLUSTER` on, see
+[Backup retention](#backup-retention). The container prints the same warning
+on every start while the option is enabled.
 
 **Budget more stop-grace time.** Copying and compressing the cluster directory
 runs once per instance, on top of the shutdown warning and the world save that

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ Basic configuration is done with environment variables:
 | UPDATE_ON_START | false | Update the ARK server and mods (with a backup, if configured) before each start |
 | VALIDATE_ON_START | false | Let `steamcmd` validate and repair the server files during `UPDATE_ON_START` — useful after a corrupted update, but makes the start noticeably slower |
 | PRE_UPDATE_BACKUP | true | Create a backup before updating the ARK server |
-| BACKUP_ON_STOP | false | Create a backup after the world save when the container is stopped gracefully. In cluster mode the `/cluster` transfer data is included, see [Cluster backups](#cluster-backups) |
+| BACKUP_ON_STOP | false | Create a backup after the world save when the container is stopped gracefully |
+| BACKUP_CLUSTER | false | Include the `/cluster` transfer data in the backups this image creates. Needs `CLUSTER_ID` and makes backups bigger and slower, read [Cluster backups](#cluster-backups) before enabling it |
 | MAX_BACKUP_SIZE_MB | `empty` | Size budget for `/app/backup`, in megabytes. arkmanager deletes the oldest backups once the directory grows past it, see [Backup retention](#backup-retention) |
 | WARN_ON_STOP | true | Broadcast a shutdown warning to players when the container is stopped gracefully |
 | ALWAYS_RESTART_ON_CRASH | `empty` | Set to `true` to let arkmanager restart an instance that crashes before it finished starting. Read [Crash restarts](#crash-restarts) first, this can loop forever |
@@ -596,8 +597,11 @@ vim "${HOME}/ark-server/crontab"
 
 Jobs run as the `steam` user.
 
-In cluster mode add `--cluster` to the backup job, otherwise the transfer data
-in `/cluster` is left out (see [Cluster backups](#cluster-backups)).
+Cron jobs are not covered by `BACKUP_CLUSTER`. Add `--cluster` to the backup
+job yourself if you want the transfer data in `/cluster` included, and read
+[Cluster backups](#cluster-backups) first. The crontab template is only copied
+when `<your-volume>/crontab` does not exist yet, so on an existing volume no
+example ever reaches you, you have to edit the file by hand.
 
 The container environment is exported to `/app/environment` on every start and
 loaded into each job via the crontab's `BASH_ENV` header, so cron jobs see the
@@ -773,7 +777,7 @@ arkmanager commands accept an instance (`@main`, `@sub.Fjordur`) or `@all`:
 
 ```bash
 docker exec -u steam ark-server arkmanager status @all
-docker exec -u steam ark-server arkmanager backup @all
+docker exec -u steam ark-server arkmanager backup @all --cluster
 ```
 
 The bundled [graceful shutdown](#graceful-shutdown) warns, saves and stops
@@ -793,28 +797,38 @@ unhealthy about five minutes after the last one is gone.
 `--cluster`. Without the flag your worlds are backed up but the uploaded
 characters, dinos and items in `/cluster` are not.
 
-The container passes `--cluster` on its own when `BACKUP_ON_STOP=true` and
-`CLUSTER_ID` is set. Everywhere else you have to add it yourself:
+Set `BACKUP_CLUSTER=true` (needs `CLUSTER_ID`) and the backups this image
+creates on its own include them, that is `BACKUP_ON_STOP` and the pre-update
+backup of `UPDATE_ON_START`. It is off by default, and the two paragraphs
+below are why. For a manual backup pass the flag yourself:
 
 ```bash
 docker exec -u steam ark-server arkmanager backup @all --cluster
 ```
 
-Same for [cronjobs](#add-cronjobs) and for the pre-update backup, which
-arkmanager runs without the flag (`PRE_UPDATE_BACKUP` covers the world, not
-the cluster). Two things to keep in mind:
+**Check your retention limit first.** `arkmanager.cfg` ships
+`arkMaxBackupSizeMB="500"`. arkmanager applies that limit after *every single
+instance backup*, not once per run: it walks the backup directory newest
+first, keeps files up to the limit and deletes everything below it. So the
+tarballs of one `@all` run count against each other. Three maps that carry the
+cluster data each can blow the limit inside a single run and leave you with the
+newest tarball and no history at all. Raise `arkMaxBackupSizeMB` in
+`<your-volume>/arkmanager/arkmanager.cfg` before you turn `BACKUP_CLUSTER` on
+(an environment variable for it is on the way). The container prints the same
+warning on every start while the option is enabled.
 
-- With sub instances every instance tarball gets its own copy of the cluster
-  directory, so backups grow with the number of maps.
-- `arkmanager.cfg` ships `arkMaxBackupSizeMB="500"`, and arkmanager silently
-  deletes the oldest backups once the backup directory passes that limit.
-  Bigger backups hit it sooner, so raise the value in
-  `<your-volume>/arkmanager/arkmanager.cfg` if you want to keep the same
-  history.
+**Budget more stop-grace time.** Copying and compressing the cluster directory
+runs once per instance, on top of the shutdown warning and the world save that
+already fill most of the grace period. Add roughly a minute per instance to the
+`stop_grace_period` from [Graceful shutdown](#graceful-shutdown), more if your
+cluster holds thousands of uploads. If docker kills the container mid-backup
+you keep a truncated archive and an uncompressed staging directory in the
+backup directory, and `arkmanager restore` without an argument picks the newest
+file in there with no name filter, so it will happily pick one of those.
 
-`arkmanager restore` puts `Cluster/*` back into the cluster directory, so when
-you [restore](#restore-a-backup) a cluster backup the throwaway container needs
-`-e CLUSTER_ID=<id>` and the `/cluster` mount as well.
+[Cronjobs](#add-cronjobs) are not covered by `BACKUP_CLUSTER`, add `--cluster`
+to the job yourself. Restoring such a backup has its own pitfalls, see
+[Restore a backup](#restore-a-backup).
 
 ### Example: 3 maps in 1 container
 
@@ -1007,9 +1021,24 @@ docker start ark-server
 If you run with `PUID`/`PGID`, replace `gosu steam` with `gosu <PUID>:<PGID>`
 (gosu accepts numeric ids) so the restored files get the right owner.
 
-Restoring a [cluster backup](#cluster-backups) additionally needs
-`-e CLUSTER_ID=<id>` and the `/cluster` mount on the throwaway container,
-otherwise arkmanager has nowhere to put the `Cluster/*` files.
+`arkmanager restore` prints `Restore Complete OK` no matter what happened, the
+line is unconditional. Check the output for `FAILED` lines and for the files it
+lists, that is the only way to see whether anything was restored at all. It
+also picks the newest file in the backup directory when you give it no
+argument, with no check on the name, so pass the tarball explicitly if a backup
+was ever interrupted.
+
+Restoring a [cluster backup](#cluster-backups) needs a few extra things:
+
+- `-e CLUSTER_ID=<id>` and the `/cluster` mount on the throwaway container,
+  writable, otherwise arkmanager has nowhere to put the `Cluster/*` files.
+- Everybody shares that volume, so restoring on one container rewrites the
+  transfer data of every other server in the cluster. Uploads that were
+  already downloaded somewhere else come back and can be downloaded a second
+  time, so stop the other servers first if that matters to you.
+- It is slow. The cluster directory holds one file per uploaded character,
+  dino and item, and arkmanager decompresses the whole archive once per file,
+  so a big cluster can take tens of minutes to hours. It is not stuck.
 
 ### Xbox crossplay?
 

--- a/README.md
+++ b/README.md
@@ -560,7 +560,9 @@ A few things worth knowing:
 * Backups are capped by `arkMaxBackupSizeMB="500"` in
   `<your-volume>/arkmanager/arkmanager.cfg`. At roughly 1-2MB per backup that
   is a few hundred of them, so `*/15 * * * *` (96 per day) keeps about three
-  to five days of history before the oldest ones get deleted.
+  to five days of history before the oldest ones get deleted. A backup with
+  `BACKUP_CLUSTER=true` is a good deal bigger, see
+  [Cluster backups](#cluster-backups).
 * Nothing serializes cron jobs and nothing locks, so keep your own jobs clear
   of the backup window.
 * There is no `UPDATE_CRON` or `RESTART_CRON`, on purpose. In this container
@@ -597,11 +599,12 @@ vim "${HOME}/ark-server/crontab"
 
 Jobs run as the `steam` user.
 
-Cron jobs are not covered by `BACKUP_CLUSTER`. Add `--cluster` to the backup
-job yourself if you want the transfer data in `/cluster` included, and read
-[Cluster backups](#cluster-backups) first. The crontab template is only copied
-when `<your-volume>/crontab` does not exist yet, so on an existing volume no
-example ever reaches you, you have to edit the file by hand.
+With `BACKUP_CLUSTER=true` the generated job gets `--cluster` and the block
+above reads `arkmanager backup @all --cluster`, see
+[Cluster backups](#cluster-backups). Jobs you wrote yourself are yours, add the
+flag there by hand. The crontab template is only copied when
+`<your-volume>/crontab` does not exist yet, so on an existing volume no example
+ever reaches you either.
 
 The container environment is exported to `/app/environment` on every start and
 loaded into each job via the crontab's `BASH_ENV` header, so cron jobs see the
@@ -797,10 +800,11 @@ unhealthy about five minutes after the last one is gone.
 `--cluster`. Without the flag your worlds are backed up but the uploaded
 characters, dinos and items in `/cluster` are not.
 
-Set `BACKUP_CLUSTER=true` (needs `CLUSTER_ID`) and the backups this image
-creates on its own include them, that is `BACKUP_ON_STOP` and the pre-update
-backup of `UPDATE_ON_START`. It is off by default, and the two paragraphs
-below are why. For a manual backup pass the flag yourself:
+Set `BACKUP_CLUSTER=true` (needs `CLUSTER_ID`) and every backup this image
+makes includes them: `BACKUP_ON_STOP`, the pre-update backup of
+`UPDATE_ON_START` and the scheduled job from `BACKUP_CRON`. It is off by
+default, and the two paragraphs below are why. For a manual backup pass the
+flag yourself:
 
 ```bash
 docker exec -u steam ark-server arkmanager backup @all --cluster
@@ -832,9 +836,9 @@ you keep a truncated archive and an uncompressed staging directory in the
 backup directory, and `arkmanager restore` without an argument picks the newest
 file in there with no name filter, so it will happily pick one of those.
 
-[Cronjobs](#add-cronjobs) are not covered by `BACKUP_CLUSTER`, add `--cluster`
-to the job yourself. Restoring such a backup has its own pitfalls, see
-[Restore a backup](#restore-a-backup).
+Only the generated `BACKUP_CRON` job picks the flag up, [cron jobs](#add-cronjobs)
+you wrote yourself need it added by hand. Restoring such a backup has its own
+pitfalls, see [Restore a backup](#restore-a-backup).
 
 ### Example: 3 maps in 1 container
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Basic configuration is done with environment variables:
 | UPDATE_ON_START | false | Update the ARK server and mods (with a backup, if configured) before each start |
 | VALIDATE_ON_START | false | Let `steamcmd` validate and repair the server files during `UPDATE_ON_START` — useful after a corrupted update, but makes the start noticeably slower |
 | PRE_UPDATE_BACKUP | true | Create a backup before updating the ARK server |
-| BACKUP_ON_STOP | false | Create a backup after the world save when the container is stopped gracefully |
+| BACKUP_ON_STOP | false | Create a backup after the world save when the container is stopped gracefully. In cluster mode the `/cluster` transfer data is included, see [Cluster backups](#cluster-backups) |
 | MAX_BACKUP_SIZE_MB | `empty` | Size budget for `/app/backup`, in megabytes. arkmanager deletes the oldest backups once the directory grows past it, see [Backup retention](#backup-retention) |
 | WARN_ON_STOP | true | Broadcast a shutdown warning to players when the container is stopped gracefully |
 | ALWAYS_RESTART_ON_CRASH | `empty` | Set to `true` to let arkmanager restart an instance that crashes before it finished starting. Read [Crash restarts](#crash-restarts) first, this can loop forever |
@@ -596,6 +596,9 @@ vim "${HOME}/ark-server/crontab"
 
 Jobs run as the `steam` user.
 
+In cluster mode add `--cluster` to the backup job, otherwise the transfer data
+in `/cluster` is left out (see [Cluster backups](#cluster-backups)).
+
 The container environment is exported to `/app/environment` on every start and
 loaded into each job via the crontab's `BASH_ENV` header, so cron jobs see the
 same variables as the server process. Both header lines are required, cron
@@ -783,6 +786,35 @@ would swap the shared server binaries underneath the still-running others.
 Stopping instances by hand shows up in the [health check](#health-check): the
 container stays healthy as long as one instance is running, and reports
 unhealthy about five minutes after the last one is gone.
+
+### Cluster backups
+
+`arkmanager backup` only picks up the cluster directory when you call it with
+`--cluster`. Without the flag your worlds are backed up but the uploaded
+characters, dinos and items in `/cluster` are not.
+
+The container passes `--cluster` on its own when `BACKUP_ON_STOP=true` and
+`CLUSTER_ID` is set. Everywhere else you have to add it yourself:
+
+```bash
+docker exec -u steam ark-server arkmanager backup @all --cluster
+```
+
+Same for [cronjobs](#add-cronjobs) and for the pre-update backup, which
+arkmanager runs without the flag (`PRE_UPDATE_BACKUP` covers the world, not
+the cluster). Two things to keep in mind:
+
+- With sub instances every instance tarball gets its own copy of the cluster
+  directory, so backups grow with the number of maps.
+- `arkmanager.cfg` ships `arkMaxBackupSizeMB="500"`, and arkmanager silently
+  deletes the oldest backups once the backup directory passes that limit.
+  Bigger backups hit it sooner, so raise the value in
+  `<your-volume>/arkmanager/arkmanager.cfg` if you want to keep the same
+  history.
+
+`arkmanager restore` puts `Cluster/*` back into the cluster directory, so when
+you [restore](#restore-a-backup) a cluster backup the throwaway container needs
+`-e CLUSTER_ID=<id>` and the `/cluster` mount as well.
 
 ### Example: 3 maps in 1 container
 
@@ -974,6 +1006,10 @@ docker start ark-server
 
 If you run with `PUID`/`PGID`, replace `gosu steam` with `gosu <PUID>:<PGID>`
 (gosu accepts numeric ids) so the restored files get the right owner.
+
+Restoring a [cluster backup](#cluster-backups) additionally needs
+`-e CLUSTER_ID=<id>` and the `/cluster` mount on the throwaway container,
+otherwise arkmanager has nowhere to put the `Cluster/*` files.
 
 ### Xbox crossplay?
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Basic configuration is done with environment variables:
 | GAME_MOD_IDS | `empty` | Additional game mods to install, separated by comma (e.g. `GAME_MOD_IDS=487516323,487516324,487516325`) |
 | UPDATE_ON_START | false | Update the ARK server and mods (with a backup, if configured) before each start |
 | VALIDATE_ON_START | false | Let `steamcmd` validate and repair the server files during `UPDATE_ON_START` — useful after a corrupted update, but makes the start noticeably slower |
-| PRE_UPDATE_BACKUP | true | Create a backup before updating the ARK server |
+| PRE_UPDATE_BACKUP | true | Create a backup before updating the ARK server, but only when there is an update to apply. `false` updates without one |
 | BACKUP_ON_STOP | false | Create a backup after the world save when the container is stopped gracefully |
 | BACKUP_CLUSTER | false | Include the `/cluster` transfer data in the backups this image creates. Needs `CLUSTER_ID` and makes backups bigger and slower, read [Cluster backups](#cluster-backups) before enabling it |
 | MAX_BACKUP_SIZE_MB | `empty` | Size budget for `/app/backup`, in megabytes. arkmanager deletes the oldest backups once the directory grows past it, see [Backup retention](#backup-retention) |
@@ -805,6 +805,12 @@ below are why. For a manual backup pass the flag yourself:
 ```bash
 docker exec -u steam ark-server arkmanager backup @all --cluster
 ```
+
+The pre-update backup only runs when there is something to update, the
+container asks `arkmanager checkupdate` and `checkmodupdate` first. A container
+that restarts in a loop therefore does not write a backup on every boot. If
+that backup fails, the start aborts instead of updating without one, and
+`PRE_UPDATE_BACKUP=false` skips it entirely.
 
 **Check your retention limit first.** `arkmanager.cfg` ships
 `arkMaxBackupSizeMB="500"`. arkmanager applies that limit after *every single

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -75,11 +75,19 @@ function render_generated_cronjobs() {
   local -i FIX_HEADER=0
   local -i HAS_BLOCK=0
 
+  # arkmanager skips the cluster directory unless the backup is called with
+  # --cluster, so without this the scheduled backups would be the only ones
+  # missing the transfer data
+  local CLUSTER_FLAG=""
+  if [[ "${BACKUP_CLUSTER}" == "true" ]] && [[ -n "${CLUSTER_ID}" ]]; then
+    CLUSTER_FLAG=" --cluster"
+  fi
+
   # @all covers every instance - identical to @main on a single-map server and
   # required on multi-map servers. Only backups are scheduled here: every
   # arkmanager command that stops the server (update, restart) kills the run
   # process this container waits on, which takes the container down with it
-  [[ -z "${BACKUP_CRON}" ]] || JOBS+=("${BACKUP_CRON} arkmanager backup @all >> ${LOG_TARGET} 2>&1")
+  [[ -z "${BACKUP_CRON}" ]] || JOBS+=("${BACKUP_CRON} arkmanager backup @all${CLUSTER_FLAG} >> ${LOG_TARGET} 2>&1")
   GENERATED_CRON_JOB_COUNT=${#JOBS[@]}
 
   if crontab_has_generated_block "${CRONTAB_FILE}"; then

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -43,7 +43,11 @@ function stop_server() {
 
   if [[ "${BACKUP_ON_STOP}" == "true" ]]; then
     echo "\$BACKUP_ON_STOP is 'true', creating a backup..."
-    ${ARKMANAGER} backup @all || echo "Backup on stop failed, continuing shutdown..."
+    # arkmanager skips the cluster directory unless it is called with
+    # --cluster, so the transfer data would never end up in a backup
+    local BACKUP_ARGS=()
+    [[ -z "${CLUSTER_ID}" ]] || BACKUP_ARGS+=(--cluster)
+    ${ARKMANAGER} backup @all "${BACKUP_ARGS[@]}" || echo "Backup on stop failed, continuing shutdown..."
   fi
 
   # terminate any run processes that are still alive (e.g. the signal arrived

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -501,8 +501,8 @@ function resolve_cluster_backup_args() {
   echo "         With sub instances every instance tarball carries its own copy,"
   echo "         and arkmanager prunes ${ARK_SERVER_VOLUME}/backup down to"
   echo "         arkMaxBackupSizeMB (500 by default) after every single instance"
-  echo "         backup. Raise the value in ${ARK_TOOLS_DIR}/arkmanager.cfg first,"
-  echo "         otherwise a backup run can delete your whole backup history."
+  echo "         backup. Raise it with MAX_BACKUP_SIZE_MB first, otherwise a backup"
+  echo "         run can delete your whole backup history."
 }
 
 # parse and validate SUB_INSTANCE_KEYS: each key becomes part of a bash

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -9,7 +9,7 @@ function may_update() {
 
   echo "\$UPDATE_ON_START is 'true'..."
 
-  local UPDATE_ARGS=(--verbose --update-mods --backup --no-autostart)
+  local UPDATE_ARGS=(--verbose --update-mods --no-autostart)
   # let steamcmd validate and repair the installed files, e.g. after a
   # corrupted download - slower, therefore opt-in
   if [[ "${VALIDATE_ON_START}" == "true" ]]; then
@@ -17,12 +17,26 @@ function may_update() {
     UPDATE_ARGS+=(--validate)
   fi
 
+  # arkmanager's own pre-update backup runs without the cluster data and
+  # 'update' exits 1 on the unknown option --cluster, so take that backup
+  # ourselves and switch the built-in one off for this call (arkmanager.cfg
+  # derives arkBackupPreUpdate from PRE_UPDATE_BACKUP)
+  local UPDATE_ENV=()
+  if [[ ${#CLUSTER_BACKUP_ARGS[@]} -gt 0 ]] && [[ "${PRE_UPDATE_BACKUP}" == "true" ]]; then
+    echo "Creating the pre-update backup including the cluster data..."
+    ${ARKMANAGER} backup @main "${CLUSTER_BACKUP_ARGS[@]}" ||
+      echo "Pre-update backup failed, continuing with the update..."
+    UPDATE_ENV=(PRE_UPDATE_BACKUP=false)
+  else
+    UPDATE_ARGS+=(--backup)
+  fi
+
   # auto checks if a update is needed, if yes, then update the server or mods
   # (otherwise it just does nothing). At boot time no instance is running yet,
   # so updating via @main is enough - post-boot updates in a multi-instance
   # setup must target @all instead (see the crontab examples), because an
   # update swaps the shared binaries but only restarts the chosen instance
-  ${ARKMANAGER} update @main "${UPDATE_ARGS[@]}" "${BETA_ARGS[@]}"
+  env "${UPDATE_ENV[@]}" "${ARKMANAGER}" update @main "${UPDATE_ARGS[@]}" "${BETA_ARGS[@]}"
 }
 
 # invoked indirectly via 'trap stop_server TERM INT'; SC2317 is what shellcheck
@@ -43,11 +57,7 @@ function stop_server() {
 
   if [[ "${BACKUP_ON_STOP}" == "true" ]]; then
     echo "\$BACKUP_ON_STOP is 'true', creating a backup..."
-    # arkmanager skips the cluster directory unless it is called with
-    # --cluster, so the transfer data would never end up in a backup
-    local BACKUP_ARGS=()
-    [[ -z "${CLUSTER_ID}" ]] || BACKUP_ARGS+=(--cluster)
-    ${ARKMANAGER} backup @all "${BACKUP_ARGS[@]}" || echo "Backup on stop failed, continuing shutdown..."
+    ${ARKMANAGER} backup @all "${CLUSTER_BACKUP_ARGS[@]}" || echo "Backup on stop failed, continuing shutdown..."
   fi
 
   # terminate any run processes that are still alive (e.g. the signal arrived
@@ -446,6 +456,29 @@ function add_warn_minutes_to_arkmanager_cfg() {
 [ -z "${UPDATE_WARN_MINUTES}" ] || arkwarnminutes="${UPDATE_WARN_MINUTES}"'
 }
 
+# arkmanager leaves the cluster directory out of every backup unless it is
+# called with --cluster, and including it costs time and backup space per
+# instance - therefore opt-in
+function resolve_cluster_backup_args() {
+  CLUSTER_BACKUP_ARGS=()
+
+  [[ "${BACKUP_CLUSTER}" == "true" ]] || return 0
+
+  if [[ -z "${CLUSTER_ID}" ]]; then
+    echo "WARNING: BACKUP_CLUSTER has no effect because CLUSTER_ID is not set - skipping the cluster data"
+
+    return 0
+  fi
+
+  CLUSTER_BACKUP_ARGS=(--cluster)
+  echo "WARNING: BACKUP_CLUSTER is 'true' - backups now also contain /cluster."
+  echo "         With sub instances every instance tarball carries its own copy,"
+  echo "         and arkmanager prunes ${ARK_SERVER_VOLUME}/backup down to"
+  echo "         arkMaxBackupSizeMB (500 by default) after every single instance"
+  echo "         backup. Raise the value in ${ARK_TOOLS_DIR}/arkmanager.cfg first,"
+  echo "         otherwise a backup run can delete your whole backup history."
+}
+
 # parse and validate SUB_INSTANCE_KEYS: each key becomes part of a bash
 # variable name (SUB_<KEY>_*), a config filename (sub.<KEY>.cfg) and an
 # arkmanager instance name - restrict keys to a safe charset and fail loudly
@@ -679,6 +712,7 @@ trap '[ -z "${STAGED_CONFIG}" ] || rm -f "${STAGED_CONFIG}"; exit 143' TERM INT
 
 parse_sub_instance_keys
 assert_valid_sub_instance_ports
+resolve_cluster_backup_args
 assert_valid_max_backup_size
 assert_valid_always_restart_on_crash
 

--- a/bin/steam-entrypoint.sh
+++ b/bin/steam-entrypoint.sh
@@ -1,5 +1,25 @@
 #!/usr/bin/env bash
 
+# arkmanager only takes its pre-update backup when it really updates something
+# (its own gate needs an app or a mod update), and ours has to follow that or
+# every container start writes a backup. 'checkupdate' exits non-zero when a
+# server update is available, 'checkmodupdate' exits zero when a mod update is.
+# --validate and --beta make arkmanager update unconditionally.
+function update_is_pending() {
+  [[ "${VALIDATE_ON_START}" != "true" ]] || return 0
+  [[ -z "${BETA}" ]] || return 0
+
+  if ! "${ARKMANAGER}" checkupdate @main >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if [[ ${#ALL_GAME_MOD_IDS[@]} -gt 0 ]] && "${ARKMANAGER}" checkmodupdate @main >/dev/null 2>&1; then
+    return 0
+  fi
+
+  return 1
+}
+
 function may_update() {
   if [[ "${UPDATE_ON_START}" != "true" ]]; then
     [[ "${VALIDATE_ON_START}" != "true" ]] ||
@@ -22,13 +42,19 @@ function may_update() {
   # ourselves and switch the built-in one off for this call (arkmanager.cfg
   # derives arkBackupPreUpdate from PRE_UPDATE_BACKUP)
   local UPDATE_ENV=()
-  if [[ ${#CLUSTER_BACKUP_ARGS[@]} -gt 0 ]] && [[ "${PRE_UPDATE_BACKUP}" == "true" ]]; then
-    echo "Creating the pre-update backup including the cluster data..."
-    ${ARKMANAGER} backup @main "${CLUSTER_BACKUP_ARGS[@]}" ||
-      echo "Pre-update backup failed, continuing with the update..."
-    UPDATE_ENV=(PRE_UPDATE_BACKUP=false)
-  else
-    UPDATE_ARGS+=(--backup)
+  if [[ "${PRE_UPDATE_BACKUP}" == "true" ]]; then
+    if [[ ${#CLUSTER_BACKUP_ARGS[@]} -gt 0 ]] && update_is_pending; then
+      echo "Creating the pre-update backup including the cluster data..."
+      if ! "${ARKMANAGER}" backup @main "${CLUSTER_BACKUP_ARGS[@]}"; then
+        echo "ERROR: the pre-update backup failed - refusing to update without one."
+        echo "       Check the output above and the free disk space on ${ARK_SERVER_VOLUME},"
+        echo "       or set PRE_UPDATE_BACKUP=false to update without a backup."
+        exit 1
+      fi
+      UPDATE_ENV=(PRE_UPDATE_BACKUP=false)
+    else
+      UPDATE_ARGS+=(--backup)
+    fi
   fi
 
   # auto checks if a update is needed, if yes, then update the server or mods
@@ -712,7 +738,6 @@ trap '[ -z "${STAGED_CONFIG}" ] || rm -f "${STAGED_CONFIG}"; exit 143' TERM INT
 
 parse_sub_instance_keys
 assert_valid_sub_instance_ports
-resolve_cluster_backup_args
 assert_valid_max_backup_size
 assert_valid_always_restart_on_crash
 
@@ -793,6 +818,7 @@ add_always_restart_on_crash_to_arkmanager_cfg
 add_warn_minutes_to_arkmanager_cfg
 warn_on_overridden_backup_budget
 remake_sub_instances_cfg
+resolve_cluster_backup_args
 
 # multi-instance needs per-instance autorestart files: the historic template
 # pinned one shared arkautorestartfile, so 'arkmanager stop @one' would

--- a/conf.d/arkmanager.cfg
+++ b/conf.d/arkmanager.cfg
@@ -29,8 +29,12 @@ arkBackupPreUpdate=${PRE_UPDATE_BACKUP}                             # set this t
 #defaultinstance_max=20                                             # Same as above, for v1.6.43 compatibility
 arkStagingDir="${ARK_SERVER_VOLUME}/staging"
 
-# Options to automatically remove old backups to keep backup size in check
-# Each compressed backup is generally about 1-2MB in size.
+# Options to automatically remove old backups to keep backup size in check.
+# After every single instance backup arkmanager keeps the newest files up to
+# this limit and deletes everything below it, so the limit has to fit a whole
+# backup run plus the history you want to keep. A compressed world backup grows
+# with the map and the number of players, and with BACKUP_CLUSTER the cluster
+# transfer data is added to every instance backup on top.
 arkMaxBackupSizeMB="500"                                            # Set to automatically remove old backups when size exceeds this limit
 #arkMaxBackupSizeGB="2"                                             # Uncomment this and comment the above to specify the limit in whole GB
 

--- a/conf.d/crontab
+++ b/conf.d/crontab
@@ -43,3 +43,9 @@ BASH_ENV=/app/environment
 # */15 * * * * arkmanager backup @all >> /app/log/crontab.log 2>&1
 # Example : backup every day at midnight
 # 0 0 * * * arkmanager backup @all >> /app/log/crontab.log 2>&1
+#
+# In cluster mode add --cluster, otherwise the uploaded characters, dinos and
+# items in /cluster are left out of the backup. With sub instances every
+# instance then carries its own copy of the cluster data.
+# Example : backup every day at midnight, cluster data included
+# 0 0 * * * arkmanager backup @all --cluster >> /app/log/crontab.log 2>&1

--- a/conf.d/crontab
+++ b/conf.d/crontab
@@ -45,7 +45,10 @@ BASH_ENV=/app/environment
 # 0 0 * * * arkmanager backup @all >> /app/log/crontab.log 2>&1
 #
 # In cluster mode add --cluster, otherwise the uploaded characters, dinos and
-# items in /cluster are left out of the backup. With sub instances every
-# instance then carries its own copy of the cluster data.
+# items in /cluster are left out of the backup. Mind the size: with sub
+# instances every instance tarball carries its own copy of the cluster data,
+# and arkmanager prunes the backup directory to arkMaxBackupSizeMB after every
+# single instance backup. Raise that value first, see the README section
+# "Cluster backups".
 # Example : backup every day at midnight, cluster data included
 # 0 0 * * * arkmanager backup @all --cluster >> /app/log/crontab.log 2>&1

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -65,6 +65,8 @@ services:
       # # Cluster / multi-map settings, see the README section
       # # "Cluster and multi-map support" for all SUB_<KEY>_* variables
       #- CLUSTER_ID=MyCluster
+      # # Include the cluster transfer data in backups, see "Cluster backups"
+      #- BACKUP_CLUSTER=true
       #- SUB_INSTANCE_KEYS=Fjordur,Caballus_P
       #- SUB_Caballus_P_SERVER_MAP_MOD_ID=1679826889
     ports:

--- a/tests/cluster_backup.bats
+++ b/tests/cluster_backup.bats
@@ -4,16 +4,19 @@ load helper
 
 setup() {
   load_entrypoint
+  stub_arkmanager_with_call_log
 
   ARKMANAGER="$(command -v arkmanager)"
   BACKUP_CLUSTER="false"
   CLUSTER_ID=""
   CLUSTER_BACKUP_ARGS=()
+  ALL_GAME_MOD_IDS=()
+  BETA=""
   BETA_ARGS=()
   ARK_RUN_PIDS=()
   UPDATE_ON_START="true"
   VALIDATE_ON_START="false"
-  PRE_UPDATE_BACKUP="true"
+  export PRE_UPDATE_BACKUP="true"
   BACKUP_ON_STOP="true"
   WARN_ON_STOP="false"
 }
@@ -24,23 +27,60 @@ pkill() {
   :
 }
 
-# the update call overrides PRE_UPDATE_BACKUP for arkmanager only, so record
-# the assignments before handing over to the real env
-env() {
-  local arg
+# Records every argument on its own, so a call that leaks an empty argument
+# (what "${CLUSTER_BACKUP_ARGS[*]}" would produce on an empty array, and what
+# makes arkmanager exit 1) cannot be mistaken for a clean one. The variable
+# comes from the process environment, so it also proves what may_update
+# actually hands over to arkmanager.
+stub_arkmanager_with_call_log() {
+  local bin_dir="${BATS_TEST_TMPDIR}/bin"
 
-  for arg in "$@"; do
-    case "${arg}" in
-      *=*) echo "env ${arg}" >> "${STUB_LOG}" ;;
-      *) break ;;
-    esac
-  done
+  mkdir -p "${bin_dir}"
+  cat <<'STUB' > "${bin_dir}/arkmanager"
+#!/usr/bin/env bash
 
-  command env "$@"
+{
+  printf 'arkmanager'
+  printf ' [%s]' "$@"
+  printf ' PRE_UPDATE_BACKUP=%s\n' "${PRE_UPDATE_BACKUP-unset}"
+} >> "${STUB_LOG}"
+
+case "${1}" in
+  checkupdate) exit "${STUB_CHECKUPDATE_STATUS:-0}" ;;
+  checkmodupdate) exit "${STUB_CHECKMODUPDATE_STATUS:-1}" ;;
+  backup) exit "${STUB_BACKUP_STATUS:-0}" ;;
+esac
+STUB
+  chmod +x "${bin_dir}/arkmanager"
+
+  export PATH="${bin_dir}:${PATH}"
 }
 
-stub_calls() {
-  cat "${STUB_LOG}"
+server_update_is_available() {
+  export STUB_CHECKUPDATE_STATUS=1
+}
+
+mod_update_is_available() {
+  ALL_GAME_MOD_IDS=(487516323)
+  export STUB_CHECKMODUPDATE_STATUS=0
+}
+
+assert_call() {
+  if ! grep -Fxq "${1}" "${STUB_LOG}"; then
+    echo "expected call: ${1}"
+    echo "actual calls:"
+    cat "${STUB_LOG}"
+    return 1
+  fi
+}
+
+refute_call_containing() {
+  if grep -Fq "${1}" "${STUB_LOG}"; then
+    echo "expected no call containing: ${1}"
+    echo "actual calls:"
+    cat "${STUB_LOG}"
+    return 1
+  fi
 }
 
 @test "no cluster arguments without the opt-in" {
@@ -77,12 +117,10 @@ stub_calls() {
   [ "${CLUSTER_BACKUP_ARGS[*]}" = "--cluster" ]
 }
 
-@test "the backup on stop stays unchanged without the opt-in" {
+@test "the backup on stop passes no empty argument without the opt-in" {
   run stop_server
 
-  run stub_calls
-  assert_contains "$output" "arkmanager backup @all"
-  assert_not_contains "$output" "--cluster"
+  assert_call "arkmanager [backup] [@all] PRE_UPDATE_BACKUP=true"
 }
 
 @test "the backup on stop includes the cluster data with the opt-in" {
@@ -92,43 +130,127 @@ stub_calls() {
 
   run stop_server
 
-  run stub_calls
-  assert_contains "$output" "arkmanager backup @all --cluster"
+  assert_call "arkmanager [backup] [@all] [--cluster] PRE_UPDATE_BACKUP=true"
 }
 
 @test "the pre-update backup stays with arkmanager without the opt-in" {
   run may_update
 
-  run stub_calls
-  assert_contains "$output" "arkmanager update @main"
-  assert_contains "$output" "--backup"
-  assert_not_contains "$output" "arkmanager backup @main"
-  assert_not_contains "$output" "env PRE_UPDATE_BACKUP"
+  assert_call "arkmanager [update] [@main] [--verbose] [--update-mods] [--no-autostart] [--backup] PRE_UPDATE_BACKUP=true"
+  refute_call_containing "[backup] [@main]"
 }
 
-@test "the pre-update backup is taken by us with the opt-in" {
+@test "no pre-update backup when nothing needs updating" {
   BACKUP_CLUSTER="true"
   CLUSTER_ID="my-cluster"
   resolve_cluster_backup_args >/dev/null
 
   run may_update
 
-  run stub_calls
-  assert_contains "$output" "arkmanager backup @main --cluster"
-  assert_contains "$output" "env PRE_UPDATE_BACKUP=false"
-  assert_contains "$output" "arkmanager update @main"
-  assert_not_contains "$output" "--backup"
+  refute_call_containing "[backup] [@main]"
+  assert_call "arkmanager [update] [@main] [--verbose] [--update-mods] [--no-autostart] [--backup] PRE_UPDATE_BACKUP=true"
 }
 
-@test "the pre-update backup is skipped when PRE_UPDATE_BACKUP is false" {
+@test "a pending server update gets a pre-update backup with the cluster data" {
   BACKUP_CLUSTER="true"
   CLUSTER_ID="my-cluster"
+  resolve_cluster_backup_args >/dev/null
+  server_update_is_available
+
+  run may_update
+
+  [ "$status" -eq 0 ]
+  assert_call "arkmanager [backup] [@main] [--cluster] PRE_UPDATE_BACKUP=true"
+  assert_call "arkmanager [update] [@main] [--verbose] [--update-mods] [--no-autostart] PRE_UPDATE_BACKUP=false"
+}
+
+@test "a pending mod update gets one too" {
+  BACKUP_CLUSTER="true"
+  CLUSTER_ID="my-cluster"
+  resolve_cluster_backup_args >/dev/null
+  mod_update_is_available
+
+  run may_update
+
+  assert_call "arkmanager [backup] [@main] [--cluster] PRE_UPDATE_BACKUP=true"
+  assert_call "arkmanager [update] [@main] [--verbose] [--update-mods] [--no-autostart] PRE_UPDATE_BACKUP=false"
+}
+
+@test "mods are not checked when none are configured" {
+  BACKUP_CLUSTER="true"
+  CLUSTER_ID="my-cluster"
+  resolve_cluster_backup_args >/dev/null
+  export STUB_CHECKMODUPDATE_STATUS=0
+
+  run may_update
+
+  refute_call_containing "[checkmodupdate]"
+  refute_call_containing "[backup] [@main]"
+}
+
+@test "a validate run always gets a pre-update backup" {
+  BACKUP_CLUSTER="true"
+  CLUSTER_ID="my-cluster"
+  VALIDATE_ON_START="true"
+  resolve_cluster_backup_args >/dev/null
+
+  run may_update
+
+  refute_call_containing "[checkupdate]"
+  assert_call "arkmanager [backup] [@main] [--cluster] PRE_UPDATE_BACKUP=true"
+  assert_call "arkmanager [update] [@main] [--verbose] [--update-mods] [--no-autostart] [--validate] PRE_UPDATE_BACKUP=false"
+}
+
+@test "a beta run always gets a pre-update backup" {
+  BACKUP_CLUSTER="true"
+  CLUSTER_ID="my-cluster"
+  BETA="Test"
+  BETA_ARGS=(--beta=Test)
+  resolve_cluster_backup_args >/dev/null
+
+  run may_update
+
+  refute_call_containing "[checkupdate]"
+  assert_call "arkmanager [backup] [@main] [--cluster] PRE_UPDATE_BACKUP=true"
+  assert_call "arkmanager [update] [@main] [--verbose] [--update-mods] [--no-autostart] [--beta=Test] PRE_UPDATE_BACKUP=false"
+}
+
+@test "a failed pre-update backup stops the update" {
+  BACKUP_CLUSTER="true"
+  CLUSTER_ID="my-cluster"
+  resolve_cluster_backup_args >/dev/null
+  server_update_is_available
+  export STUB_BACKUP_STATUS=1
+
+  run may_update
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "refusing to update without one"
+  refute_call_containing "[update] [@main]"
+}
+
+@test "PRE_UPDATE_BACKUP=false updates without any backup" {
+  BACKUP_CLUSTER="true"
+  CLUSTER_ID="my-cluster"
+  export PRE_UPDATE_BACKUP="false"
+  resolve_cluster_backup_args >/dev/null
+  server_update_is_available
+
+  run may_update
+
+  refute_call_containing "[backup]"
+  assert_call "arkmanager [update] [@main] [--verbose] [--update-mods] [--no-autostart] PRE_UPDATE_BACKUP=false"
+}
+
+@test "the startup sequence resolves the cluster backup arguments" {
+  run grep -cx "resolve_cluster_backup_args" "${REPO_ROOT}/bin/steam-entrypoint.sh"
+
+  [ "$output" = "1" ]
+}
+
+@test "arkmanager.cfg derives its pre-update backup from PRE_UPDATE_BACKUP" {
   PRE_UPDATE_BACKUP="false"
-  resolve_cluster_backup_args >/dev/null
+  source "${TEMPLATE_DIRECTORY}/arkmanager.cfg"
 
-  run may_update
-
-  run stub_calls
-  assert_not_contains "$output" "arkmanager backup @main"
-  assert_contains "$output" "arkmanager update @main"
+  [ "${arkBackupPreUpdate}" = "false" ]
 }

--- a/tests/cluster_backup.bats
+++ b/tests/cluster_backup.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+
+load helper
+
+setup() {
+  load_entrypoint
+
+  ARKMANAGER="$(command -v arkmanager)"
+  BACKUP_CLUSTER="false"
+  CLUSTER_ID=""
+  CLUSTER_BACKUP_ARGS=()
+  BETA_ARGS=()
+  ARK_RUN_PIDS=()
+  UPDATE_ON_START="true"
+  VALIDATE_ON_START="false"
+  PRE_UPDATE_BACKUP="true"
+  BACKUP_ON_STOP="true"
+  WARN_ON_STOP="false"
+}
+
+# stop_server signals its own children and ends the shell, neither of which
+# belongs in a test run
+pkill() {
+  :
+}
+
+# the update call overrides PRE_UPDATE_BACKUP for arkmanager only, so record
+# the assignments before handing over to the real env
+env() {
+  local arg
+
+  for arg in "$@"; do
+    case "${arg}" in
+      *=*) echo "env ${arg}" >> "${STUB_LOG}" ;;
+      *) break ;;
+    esac
+  done
+
+  command env "$@"
+}
+
+stub_calls() {
+  cat "${STUB_LOG}"
+}
+
+@test "no cluster arguments without the opt-in" {
+  run resolve_cluster_backup_args
+
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+  [ "${#CLUSTER_BACKUP_ARGS[@]}" -eq 0 ]
+}
+
+@test "the opt-in without a cluster id warns and stays inactive" {
+  BACKUP_CLUSTER="true"
+
+  run resolve_cluster_backup_args
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "BACKUP_CLUSTER has no effect because CLUSTER_ID is not set"
+
+  resolve_cluster_backup_args >/dev/null
+  [ "${#CLUSTER_BACKUP_ARGS[@]}" -eq 0 ]
+}
+
+@test "the opt-in with a cluster id adds --cluster and warns about the retention limit" {
+  BACKUP_CLUSTER="true"
+  CLUSTER_ID="my-cluster"
+
+  run resolve_cluster_backup_args
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "arkMaxBackupSizeMB"
+  assert_contains "$output" "delete your whole backup history"
+
+  resolve_cluster_backup_args >/dev/null
+  [ "${CLUSTER_BACKUP_ARGS[*]}" = "--cluster" ]
+}
+
+@test "the backup on stop stays unchanged without the opt-in" {
+  run stop_server
+
+  run stub_calls
+  assert_contains "$output" "arkmanager backup @all"
+  assert_not_contains "$output" "--cluster"
+}
+
+@test "the backup on stop includes the cluster data with the opt-in" {
+  BACKUP_CLUSTER="true"
+  CLUSTER_ID="my-cluster"
+  resolve_cluster_backup_args >/dev/null
+
+  run stop_server
+
+  run stub_calls
+  assert_contains "$output" "arkmanager backup @all --cluster"
+}
+
+@test "the pre-update backup stays with arkmanager without the opt-in" {
+  run may_update
+
+  run stub_calls
+  assert_contains "$output" "arkmanager update @main"
+  assert_contains "$output" "--backup"
+  assert_not_contains "$output" "arkmanager backup @main"
+  assert_not_contains "$output" "env PRE_UPDATE_BACKUP"
+}
+
+@test "the pre-update backup is taken by us with the opt-in" {
+  BACKUP_CLUSTER="true"
+  CLUSTER_ID="my-cluster"
+  resolve_cluster_backup_args >/dev/null
+
+  run may_update
+
+  run stub_calls
+  assert_contains "$output" "arkmanager backup @main --cluster"
+  assert_contains "$output" "env PRE_UPDATE_BACKUP=false"
+  assert_contains "$output" "arkmanager update @main"
+  assert_not_contains "$output" "--backup"
+}
+
+@test "the pre-update backup is skipped when PRE_UPDATE_BACKUP is false" {
+  BACKUP_CLUSTER="true"
+  CLUSTER_ID="my-cluster"
+  PRE_UPDATE_BACKUP="false"
+  resolve_cluster_backup_args >/dev/null
+
+  run may_update
+
+  run stub_calls
+  assert_not_contains "$output" "arkmanager backup @main"
+  assert_contains "$output" "arkmanager update @main"
+}

--- a/tests/cron_render.bats
+++ b/tests/cron_render.bats
@@ -244,6 +244,63 @@ setup() {
   [ "${GENERATED_CRON_JOB_COUNT}" -eq 1 ]
 }
 
+# the shipped template documents the flag in a comment, so only active job
+# lines can answer whether the generated job carries it
+generated_cluster_job_lines() {
+  grep -c '^[^#]*arkmanager backup @all --cluster' "${ARK_SERVER_VOLUME}/crontab" || true
+}
+
+@test "the backup job leaves the cluster data out without the opt-in" {
+  BACKUP_CRON="0 3 * * *"
+  CLUSTER_ID="my-cluster"
+
+  render_generated_cronjobs
+
+  run cat "${ARK_SERVER_VOLUME}/crontab"
+  assert_contains "$output" "0 3 * * * arkmanager backup @all >> ${ARK_SERVER_VOLUME}/log/crontab.log 2>&1"
+  [ "$(generated_cluster_job_lines)" -eq 0 ]
+}
+
+@test "the backup job takes the cluster data with the opt-in" {
+  BACKUP_CRON="0 3 * * *"
+  BACKUP_CLUSTER="true"
+  CLUSTER_ID="my-cluster"
+
+  render_generated_cronjobs
+
+  run cat "${ARK_SERVER_VOLUME}/crontab"
+  assert_contains "$output" "0 3 * * * arkmanager backup @all --cluster >> ${ARK_SERVER_VOLUME}/log/crontab.log 2>&1"
+  [ "$(generated_job_lines)" -eq 1 ]
+}
+
+@test "the opt-in without a cluster id changes nothing" {
+  BACKUP_CRON="0 3 * * *"
+  BACKUP_CLUSTER="true"
+  CLUSTER_ID=""
+
+  render_generated_cronjobs
+
+  run cat "${ARK_SERVER_VOLUME}/crontab"
+  assert_contains "$output" "0 3 * * * arkmanager backup @all >> ${ARK_SERVER_VOLUME}/log/crontab.log 2>&1"
+  [ "$(generated_cluster_job_lines)" -eq 0 ]
+}
+
+@test "turning the opt-in off again drops the flag from the block" {
+  BACKUP_CRON="0 3 * * *"
+  BACKUP_CLUSTER="true"
+  CLUSTER_ID="my-cluster"
+  render_generated_cronjobs
+
+  BACKUP_CLUSTER="false"
+  render_generated_cronjobs
+
+  run cat "${ARK_SERVER_VOLUME}/crontab"
+  assert_contains "$output" "0 3 * * * arkmanager backup @all >> ${ARK_SERVER_VOLUME}/log/crontab.log 2>&1"
+  [ "$(generated_cluster_job_lines)" -eq 0 ]
+  assert_contains "$output" "0 1 * * * echo hi"
+  [ "$(generated_job_lines)" -eq 1 ]
+}
+
 @test "rendering never calls arkmanager or steamcmd" {
   BACKUP_CRON="0 3 * * *"
 


### PR DESCRIPTION
We set `arkopt_ClusterDirOverride="/cluster"` and warn people that losing that
directory costs them their uploaded characters, dinos and items, but no backup
ever contained it. `arkmanager backup` only copies the cluster dir when it is
called with `--cluster` (its `backupCluster` stays unset otherwise), and we
never passed the flag.

## The opt in

New variable `BACKUP_CLUSTER`, default `false`. With `CLUSTER_ID` set and this
on, the backups the image creates on its own include `/cluster`: the
`BACKUP_ON_STOP` one and the pre-update backup of `UPDATE_ON_START`. Off, the
command lines are byte for byte what they were before.

It is not derived from `CLUSTER_ID` on purpose. `arkmanager` applies
`arkMaxBackupSizeMB` at the end of *every single instance backup*, not once per
run, and it keeps the newest files up to the limit and deletes the rest. Our
config ships 500. Three maps that each carry the cluster data can pass that
inside one `docker stop`, and the run then deletes its own siblings plus the
entire history. Today the same three tarballs stay well under the cap. Somebody
who upgrades through watchtower and never opens the README would lose months of
backups without touching anything, so they get to choose. The README says to
raise `arkMaxBackupSizeMB` first and notes that an env var for it is on the way
(#173).

## The update window

With the opt in on, `may_update` takes the pre-update backup itself with
`--cluster` and switches arkmanager's built-in one off for that call
(`PRE_UPDATE_BACKUP=false` in the environment, our `arkmanager.cfg` derives
`arkBackupPreUpdate` from it). `doUpdate` calls `doBackup` with no arguments and
exits 1 on the unknown option `--cluster`, so there is no way to pass it
through. A broken ARK patch is the scenario that backup exists for, and without
this it restores the world and drops every uploaded character, dino and item.

It only fires when an update is really going to happen, the same condition
arkmanager uses for its own pre-update backup (`appupdate` or `modupdate`).
`arkmanager checkupdate` exits non-zero when a server update is available,
`checkmodupdate` exits zero when a mod update is (and is only consulted when
mods are configured), and `--validate` or `--beta` make arkmanager update
unconditionally. Without that gate a container in a restart loop under
`restart: unless-stopped` would write a world plus cluster tarball on every
boot and the prune, which keeps the newest files only, would drop the real
history within a handful of restarts.

If the backup fails, the start aborts instead of updating without one. Same
reasoning as the install path refusing to continue on an incomplete download.
`PRE_UPDATE_BACKUP=false` skips it, and that variable now actually does what it
says: `--backup` used to be passed to every update, which set
`arkBackupPreUpdate=true` in arkmanager regardless of the setting.

## What else changed

- Startup warning while `BACKUP_CLUSTER` is on: names the retention cap, where
  to raise it, and that every instance tarball carries its own copy.
- Docs on the cost: the cluster copy plus bzip2 runs once per instance, after
  the warning and the world save have already eaten most of the grace period,
  so budget about a minute per instance on top of `stop_grace_period`. A
  SIGKILL mid-tar leaves a truncated archive and a staging directory behind,
  and `arkmanager restore` with no argument picks the newest file in the backup
  dir with no name filter.
- Restore section: `Restore Complete OK` is printed unconditionally, so look
  for `FAILED` lines. The `/cluster` mount has to be there and be writable.
  Restoring on one container rewrites the transfer data for every other server
  sharing that volume, which can resurrect uploads that were already downloaded
  elsewhere (new hazard, no tarball contained `Cluster/*` before this PR). And
  it is slow: one file per upload, and arkmanager decompresses the whole
  archive once per file, so a big cluster can take hours.
- Fixed the "generally about 1-2MB" comment above `arkMaxBackupSizeMB`, which
  was already wrong and is off by orders of magnitude once the cluster data is
  in there.
- The `arkmanager backup @all` example in the cluster section got the flag, the
  crontab template got a commented example plus the size warning, and the
  README says the template only lands on volumes that have no `crontab` yet, so
  existing installs have to add the flag by hand.

## Verification

Rebased onto master after #167, #168 and #172. The argument building is a
function (`resolve_cluster_backup_args`) above the source guard, called from
the startup sequence next to `parse_sub_instance_keys`.

`tests/cluster_backup.bats` adds 16 cases on top of the suite: the opt in off,
on without `CLUSTER_ID` (warns, no flag), on with it, the stop backup with and
without the flag, and every pre-update path (nothing pending, server update,
mod update, no mods configured, validate, beta, failed backup,
`PRE_UPDATE_BACKUP=false`). Its arkmanager stub records each argument
separately, so an empty argument from an array expanded with `[*]` shows up,
and it records the environment the call was made with, so the
`PRE_UPDATE_BACKUP=false` override is proven rather than assumed. Two more
cases pin the startup call and tie the variable name to `arkmanager.cfg`.
`bats tests` is 90/90 green, shellcheck (the CI invocation, all severities) and
yamllint are clean. No image build, an ARK install pulls 25GB.

Closes #159
