### PR TITLE
Document staged updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Everything the server needs lives in the volume mounted at `/app`
 | `/app/server` | The ARK dedicated server installation |
 | `/app/backup` | Backups created by `arkmanager backup` |
 | `/app/log` | arkmanager log files |
-| `/app/staging` | Staging directory for server updates |
+| `/app/staging` | Staging directory for [staged updates](#staged-updates-shorter-downtime) |
 | `/app/crontab` | Cron definitions loaded at container start |
 | `/app/environment` | Auto-generated on every start: container environment for cron jobs (contains credentials, mode 600) |
 | `/app/arkmanager` | Persisted arkmanager configuration (global + instance). `instances/sub.*.cfg` are auto-regenerated on every start |
@@ -268,6 +268,39 @@ The crontab is loaded when the container starts, so apply your changes with:
 ```bash
 docker restart ark-server
 ```
+
+#### Staged updates (shorter downtime)
+
+A plain `arkmanager update` downloads the new build with the server already
+stopped, so players sit out the whole steamcmd run. The image wires
+`/app/staging` up as arkmanager's staging directory, which lets you split that
+into two jobs: `--downloadonly` fetches the new build while the server keeps
+serving players, and a later `--no-download` copies it into place and restarts.
+Only the second job costs downtime, and it is short because staging and the
+server files live on the same volume, so the copy is hardlinks and not real
+data.
+
+```bash
+0 4 * * * arkmanager update @all --downloadonly --update-mods >> /app/log/crontab.log 2>&1
+0 6 * * * arkmanager update @all --no-download --update-mods --warn >> /app/log/crontab.log 2>&1
+```
+
+The gap between the two can be hours, the apply job simply takes whatever is in
+staging. Schedule both or neither, though: on its own the apply job stops the
+server, copies back the staging content it already has and starts again,
+without picking up the new build. `--warn` obeys `arkwarnminutes` from
+`arkmanager.cfg` (60 here), so the 6am job actually restarts at 7am. Mods only
+get their download moved out of the downtime window, the slow unpacking into
+the server still happens in the apply job. And if Wildcard ships another build
+between the two jobs you get the one you staged, the next cycle catches up.
+
+Keep some disk headroom for this. Staging is seeded with hardlinks so it starts
+out nearly free, but each update needs room for the files it replaces (a few GB
+in practice). Mounting `/app/staging` from a different filesystem than
+`/app/server` makes arkmanager fall back to rsync, which means a full second
+copy of the server and a slow apply, so don't. Note that the entrypoint's disk
+check only guards the very first install (25 GB) and never runs again, nothing
+warns you when the volume fills up later.
 
 ### Configure a Steam login session
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Everything the server needs lives in the volume mounted at `/app`
 | `/app/server` | The ARK dedicated server installation |
 | `/app/backup` | Backups created by `arkmanager backup` |
 | `/app/log` | arkmanager log files |
-| `/app/staging` | Staging directory for [staged updates](#staged-updates-shorter-downtime) |
+| `/app/staging` | Staging directory arkmanager downloads updates into, see [staged updates](#staged-updates) |
 | `/app/crontab` | Cron definitions loaded at container start |
 | `/app/environment` | Auto-generated on every start: container environment for cron jobs (contains credentials, mode 600) |
 | `/app/arkmanager` | Persisted arkmanager configuration (global + instance). `instances/sub.*.cfg` are auto-regenerated on every start |
@@ -269,38 +269,58 @@ The crontab is loaded when the container starts, so apply your changes with:
 docker restart ark-server
 ```
 
-#### Staged updates (shorter downtime)
+#### Staged updates
 
-A plain `arkmanager update` downloads the new build with the server already
-stopped, so players sit out the whole steamcmd run. The image wires
-`/app/staging` up as arkmanager's staging directory, which lets you split that
-into two jobs: `--downloadonly` fetches the new build while the server keeps
-serving players, and a later `--no-download` copies it into place and restarts.
-Only the second job costs downtime, and it is short because staging and the
-server files live on the same volume, so the copy is hardlinks and not real
-data.
+The single update job above already keeps players online for the download. This
+image points arkmanager's `arkStagingDir` at `/app/staging`, so an update first
+pulls the new build (and the mod downloads) into staging with the server still
+running, and only then stops it, swaps the files and starts again. The stop is
+short because `ShooterGame`, `Engine` and `linux64` are hardlinked out of
+staging and only `steamapps` is copied for real. What is left inside the
+downtime window is unpacking updated mods, `--update-mods` does that after the
+stop.
+
+So splitting the job into `--downloadonly` and `--no-download` does not move the
+download out of the downtime window, that already happens. It buys exactly one
+thing: you pick when the restart lands instead of taking it whenever the cron
+job happens to find an update. If you don't care about that, keep the single job
+and skip the rest of this section.
 
 ```bash
-0 4 * * * arkmanager update @all --downloadonly --update-mods >> /app/log/crontab.log 2>&1
-0 6 * * * arkmanager update @all --no-download --update-mods --warn >> /app/log/crontab.log 2>&1
+# every hour: check for a new build and pull it into staging, nothing stops
+0 * * * * arkmanager update @all --downloadonly --update-mods >> /app/log/crontab.log 2>&1
+# 6am: apply it, but only if something new really is staged
+0 6 * * * cmp -s /app/server/steamapps/appmanifest_376030.acf /app/staging/steamapps/appmanifest_376030.acf || arkmanager update @all --no-download --update-mods --warn >> /app/log/crontab.log 2>&1
 ```
 
-The gap between the two can be hours, the apply job simply takes whatever is in
-staging. Schedule both or neither, though: on its own the apply job stops the
-server, copies back the staging content it already has and starts again,
-without picking up the new build. `--warn` obeys `arkwarnminutes` from
-`arkmanager.cfg` (60 here), so the 6am job actually restarts at 7am. Mods only
-get their download moved out of the downtime window, the slow unpacking into
-the server still happens in the apply job. And if Wildcard ships another build
-between the two jobs you get the one you staged, the next cycle catches up.
+That `cmp` guard is not decoration. The apply job never compares the staged
+build with the installed one, it only asks Steam whether an update exists, and
+staging is never cleared. So whenever staging holds the build you are already
+running (the download failed, or the new build shipped after the last download
+ran), the unguarded job warns players, stops, copies identical files back,
+starts again and leaves you on the old build until the next cycle. The guard
+turns that into a no-op. It has two blind spots: a mod-only update slips past
+it, and before the first download job has ever run there is no staged manifest
+at all, which counts as different. Downloading hourly instead of once keeps
+staging fresh enough that the 6am window usually has something to apply. And if
+a newer build appears between the last download and the apply, you get the one
+you staged and the next cycle catches up.
 
-Keep some disk headroom for this. Staging is seeded with hardlinks so it starts
-out nearly free, but each update needs room for the files it replaces (a few GB
-in practice). Mounting `/app/staging` from a different filesystem than
-`/app/server` makes arkmanager fall back to rsync, which means a full second
-copy of the server and a slow apply, so don't. Note that the entrypoint's disk
-check only guards the very first install (25 GB) and never runs again, nothing
-warns you when the volume fills up later.
+About the countdown. `--warn` counts down `arkwarnminutes` from
+`arkmanager.cfg` (60 here), but `arkprecisewarn` is `false`, so with nobody
+online arkmanager broadcasts "Nobody is connected" and restarts right away.
+With `@all` on a multi-map setup the instances are handled one after another,
+so every map gets its own countdown and the last one finishes much later than
+the first. An apply job that finds no pending update does nothing at all, no
+stop and no start.
+
+Keep some disk headroom for staging. It is seeded once by hardlinking the
+installed server, so it starts out nearly free, but every update needs room for
+the files it replaces (a few GB in practice). If `/app/staging` and
+`/app/server` end up on different filesystems, arkmanager falls back to rsync,
+which means a full second copy of the server and a slow apply, so keep both in
+the same volume. The entrypoint's disk check only guards the very first install
+(25 GB) and never runs again, nothing warns you when the volume fills up later.
 
 ### Configure a Steam login session
 

--- a/conf.d/crontab
+++ b/conf.d/crontab
@@ -23,6 +23,17 @@ BASH_ENV=/app/environment
 # so it must stop/restart all instances, not just one)
 # Example : update every day at 4am
 # 0 4 * * * arkmanager update @all --warn --update-mods >> /app/log/crontab.log 2>&1
+#
+# Example : staged update, pull the new build into /app/staging at 4am while
+#           players keep playing, apply it at 6am with a warning countdown.
+#           Only the second job stops the server, and it is short because the
+#           files are already there. Schedule both or neither: the apply job on
+#           its own stops the server, copies back what is already in staging and
+#           starts again, without picking up anything new.
+#           --warn obeys arkwarnminutes (60 by default), so the 6am job really
+#           restarts at 7am. Details and disk notes in the README.
+# 0 4 * * * arkmanager update @all --downloadonly --update-mods >> /app/log/crontab.log 2>&1
+# 0 6 * * * arkmanager update @all --no-download --update-mods --warn >> /app/log/crontab.log 2>&1
 # Example : backup every 15min
 # */15 * * * * arkmanager backup @all >> /app/log/crontab.log 2>&1
 # Example : backup every day at midnight

--- a/conf.d/crontab
+++ b/conf.d/crontab
@@ -24,16 +24,14 @@ BASH_ENV=/app/environment
 # Example : update every day at 4am
 # 0 4 * * * arkmanager update @all --warn --update-mods >> /app/log/crontab.log 2>&1
 #
-# Example : staged update, pull the new build into /app/staging at 4am while
-#           players keep playing, apply it at 6am with a warning countdown.
-#           Only the second job stops the server, and it is short because the
-#           files are already there. Schedule both or neither: the apply job on
-#           its own stops the server, copies back what is already in staging and
-#           starts again, without picking up anything new.
-#           --warn obeys arkwarnminutes (60 by default), so the 6am job really
-#           restarts at 7am. Details and disk notes in the README.
-# 0 4 * * * arkmanager update @all --downloadonly --update-mods >> /app/log/crontab.log 2>&1
-# 0 6 * * * arkmanager update @all --no-download --update-mods --warn >> /app/log/crontab.log 2>&1
+# The job above already downloads into /app/staging with the server running and
+# only stops it to swap the files. Split it in two only if you want the restart
+# to land at a fixed hour: download hourly, apply at 6am. The cmp guard is
+# required, without it the 6am job stops and restarts the server even when
+# staging holds the build you are already running. See the README.
+# 0 * * * * arkmanager update @all --downloadonly --update-mods >> /app/log/crontab.log 2>&1
+# 0 6 * * * cmp -s /app/server/steamapps/appmanifest_376030.acf /app/staging/steamapps/appmanifest_376030.acf || arkmanager update @all --no-download --update-mods --warn >> /app/log/crontab.log 2>&1
+#
 # Example : backup every 15min
 # */15 * * * * arkmanager backup @all >> /app/log/crontab.log 2>&1
 # Example : backup every day at midnight


### PR DESCRIPTION
We configure `arkStagingDir`, create `/app/staging` and list it in the data layout table, but never say what it is for. Docs only, no behavior change.

The first version of this section got the premise wrong and the review caught it, so the second commit rewrites it around what the code actually does.

Since we set `arkStagingDir` in `conf.d/arkmanager.cfg`, the plain update job we already document takes the staging path: it downloads the new build (and the mod downloads) with the server still running, and only then stops it, hardlinks the files over and starts again. So the download is already outside the downtime window and splitting the job does not change that. What splitting buys you is control over when the restart lands, nothing else. The section says that outright and tells you to keep the single job if you don't care.

The other correction is the trap. The apply job never compares the staged build against the installed one, it only asks Steam whether an update exists, and the staging tree is never cleared. So whenever staging holds the build you are already running (failed download, or the new build shipped after the last download ran) the apply job warns players, stops, copies identical files back and starts again, leaving you on the old build. My first version blamed the wrong condition and gave advice that did not avoid it. The examples now download hourly and guard the apply job with `cmp` on `appmanifest_376030.acf`, which turns the pointless restart into a no-op. Blind spots are documented too: mod-only updates slip past the guard, and before the first download there is no staged manifest to compare.

Smaller fixes in the same pass:

* `arkprecisewarn` is `false` here, so with nobody online arkmanager restarts immediately instead of counting down `arkwarnminutes`, and with `@all` the countdown runs per instance, one map after another.
* An apply job with no pending update does nothing at all, no stop and no start.
* Only `ShooterGame`, `Engine` and `linux64` are hardlinked, `steamapps` is a real copy.

Kept from the first version: the rsync fallback when staging and the server sit on different filesystems, the note that `bin/steam-entrypoint.sh` only checks 25 GB on the very first install, and what happens when a newer build appears between the two jobs.

Closes #163
